### PR TITLE
feat: 데모 앱 Player 재생 시 재생 파형 그리기 기능 추가

### DIFF
--- a/alsongDalsong/ASAudioKit/ASAudioDemo/ASAudioKitDemoView.swift
+++ b/alsongDalsong/ASAudioKit/ASAudioDemo/ASAudioKitDemoView.swift
@@ -6,7 +6,7 @@ struct ASAudioKitDemoView: View {
     var body: some View {
         VStack {
             if viewModel.isRecording {
-                AudioVisualizerViewWrapper(amplitude: $viewModel.amplitude)
+                AudioVisualizerViewWrapper(amplitude: $viewModel.recorderAmplitude)
                     .frame(height: 200)
                     .frame(maxWidth: .infinity)
                     .padding(.bottom, 10)
@@ -42,6 +42,11 @@ struct ASAudioKitDemoView: View {
                 
                 ProgressBar(progress: Float(viewModel.playedTime) / Float(viewModel.getDuration(recordedFile: file) ?? 0))
                     .frame(height: 2)
+                    .padding(.bottom, 10)
+                
+                AudioVisualizerViewWrapper(amplitude: $viewModel.playerAmplitude)
+                    .frame(height: 100)
+                    .frame(maxWidth: .infinity)
             }
             else {
                 Image(systemName: "play.slash")

--- a/alsongDalsong/ASAudioKit/ASAudioDemo/AudioVisualizerView.swift
+++ b/alsongDalsong/ASAudioKit/ASAudioDemo/AudioVisualizerView.swift
@@ -5,7 +5,7 @@ class AudioVisualizerView: UIView {
     var columnWidth: CGFloat?
     var columns: [CAShapeLayer] = []
     var amplitudesHistory: [CGFloat] = []
-    let numOfColumns: Int = 20
+    let numOfColumns: Int = 43
     
     override class func awakeFromNib() {
         super.awakeFromNib()
@@ -81,4 +81,3 @@ struct AudioVisualizerViewWrapper: UIViewRepresentable {
         uiView.updateVisualizerView(with: CGFloat(amplitude))
     }
 }
-

--- a/alsongDalsong/ASAudioKit/ASAudioKit/ASAudioPlayer/ASAudioPlayer.swift
+++ b/alsongDalsong/ASAudioKit/ASAudioKit/ASAudioPlayer/ASAudioPlayer.swift
@@ -17,6 +17,7 @@ public final class ASAudioPlayer: NSObject, Sendable, AVAudioPlayerDelegate {
             audioPlayer = try AVAudioPlayer(data: data)
             audioPlayer?.delegate = self
             audioPlayer?.prepareToPlay()
+            audioPlayer?.isMeteringEnabled = true
         } catch {
             // TODO: 오디오 객체생성 실패 시 처리
         }
@@ -53,6 +54,14 @@ public final class ASAudioPlayer: NSObject, Sendable, AVAudioPlayerDelegate {
             }
         }
         return audioPlayer?.duration ?? 0
+    }
+    
+    public func updateMeters() {
+        audioPlayer?.updateMeters()
+    }
+    /// player에 입력된 평균 dB을 리턴합니다.
+    public func getAveragePower() -> Float? {
+        return audioPlayer?.averagePower(forChannel: 0)
     }
     
     public func audioPlayerDidFinishPlaying(_ player: AVAudioPlayer, successfully flag: Bool) {


### PR DESCRIPTION
## What is this PR?
- 데모 앱에 Player 재생 시 재생 파형 그리기 추가

## PR Type
- [ ] Bugfix
- [ ] Chore
- [x] New feature (기능을 추가하는 feat)
- [ ] Breaking change (기존의 기능이 동작하지 않을 수 있는 fix/feat)
- [ ] Documentation Update

## ScreenShot(if available)
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "https://github.com/user-attachments/assets/51f5212f-64cd-44d3-ba8e-338addf908c4" width ="250">|

## Further comments
녹음 파일을 분석해 파형을 미리 그려보려고 하였으나, 생각처럼 잘되지 않아 일단은 AVPlayer에서 재생되는 amplitudes를 실시간으로 얻어 파형을 그리게 만들었습니다.