### PR TITLE
QA: HummingView UI 업데이트/수정

### DIFF
--- a/alsongDalsong/ASEntity/ASEntity/Music.swift
+++ b/alsongDalsong/ASEntity/ASEntity/Music.swift
@@ -4,6 +4,8 @@ public struct Music: Codable, Equatable {
     public var id: UUID?
     public var title: String?
     public var artist: String?
+    public var artworkUrl: URL?
+    public var previewUrl: URL?
     public var lyrics: String?
 
     public init() {}
@@ -11,5 +13,12 @@ public struct Music: Codable, Equatable {
     public init(title: String, artist: String) {
         self.title = title
         self.artist = artist
+    }
+    
+    public init(title: String, artist: String, artworkUrl: URL?, previewUrl: URL?) {
+        self.title = title
+        self.artist = artist
+        self.artworkUrl = artworkUrl
+        self.previewUrl = previewUrl
     }
 }

--- a/alsongDalsong/ASRepository/ASRepository/Protocols/RepositoryProtocols.swift
+++ b/alsongDalsong/ASRepository/ASRepository/Protocols/RepositoryProtocols.swift
@@ -4,6 +4,7 @@ import Foundation
 
 public protocol AnswersRepositoryProtocol {
     func getAnswers() -> AnyPublisher<[Answer], Never>
+    func getMyAnswer() -> AnyPublisher<Answer?, Never>
 }
 
 public protocol GameStatusRepositoryProtocol {

--- a/alsongDalsong/ASRepository/ASRepository/Repositories/AnswersRepository.swift
+++ b/alsongDalsong/ASRepository/ASRepository/Repositories/AnswersRepository.swift
@@ -15,4 +15,16 @@ public final class AnswersRepository: AnswersRepositoryProtocol {
             .compactMap { $0 }
             .eraseToAnyPublisher()
     }
+    
+    public func getMyAnswer() -> AnyPublisher<Answer?, Never> {
+        mainRepository.answers
+            .receive(on: DispatchQueue.main)
+            .compactMap(\.self)
+            .flatMap { answers in
+                // TODO: - myId를 (저장해 두었다가 또는 가져와서) 필터링 필요
+                return Just(answers.first/* { $0.player?.id == "myId"}*/)
+                    .eraseToAnyPublisher()
+            }
+            .eraseToAnyPublisher()
+    }
 }

--- a/alsongDalsong/ASRepository/ASRepository/Repositories/MainRepository.swift
+++ b/alsongDalsong/ASRepository/ASRepository/Repositories/MainRepository.swift
@@ -36,6 +36,7 @@ public final class MainRepository: MainRepositoryProtocol {
                     return
                 }
             } receiveValue: { [weak self] room in
+                print(room)
                 guard let self = self else { return }
                 self.update(\.number, with: room.number)
                 self.update(\.host, with: room.host)

--- a/alsongDalsong/ASRepository/ASRepository/Repositories/MainRepository.swift
+++ b/alsongDalsong/ASRepository/ASRepository/Repositories/MainRepository.swift
@@ -4,7 +4,6 @@ import Combine
 import Foundation
 
 public final class MainRepository: MainRepositoryProtocol {
-    
     public var number = CurrentValueSubject<String?, Never>(nil)
     public var host = CurrentValueSubject<Player?, Never>(nil)
     public var players = CurrentValueSubject<[Player]?, Never>(nil)
@@ -36,7 +35,6 @@ public final class MainRepository: MainRepositoryProtocol {
                     return
                 }
             } receiveValue: { [weak self] room in
-                print(room)
                 guard let self = self else { return }
                 self.update(\.number, with: room.number)
                 self.update(\.host, with: room.host)

--- a/alsongDalsong/ASRepository/ASRepository/Repositories/MusicRepository.swift
+++ b/alsongDalsong/ASRepository/ASRepository/Repositories/MusicRepository.swift
@@ -6,21 +6,26 @@ public final class MusicRepository: MusicRepositoryProtocol {
     // TODO: - Container로 주입
     private let firebaseManager: ASFirebaseStorageProtocol
     private let networkManager: ASNetworkManagerProtocol
-    
-    public init (
+
+    public init(
         firebaseManager: ASFirebaseStorageProtocol,
         networkManager: ASNetworkManagerProtocol
     ) {
         self.firebaseManager = firebaseManager
         self.networkManager = networkManager
     }
-    
+
     public func getMusicData(url: URL) -> Future<Data?, Error> {
         Future { promise in
             Task {
                 do {
-                    guard let endpoint = ResourceEndpoint(url: url) else { return promise(.failure(ASNetworkErrors.urlError)) }
-                    let data = try await self.networkManager.sendRequest(to: endpoint, body: nil, option: .both)
+                    guard let endpoint = ResourceEndpoint(url: url)
+                    else { return promise(.failure(ASNetworkErrors.urlError)) }
+                    let data = try await self.networkManager.sendRequest(
+                        to: endpoint,
+                        body: nil,
+                        option: .both
+                    )
                     promise(.success(data))
                 } catch {
                     promise(.failure(error))

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/ASAlertController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/ASAlertController.swift
@@ -40,7 +40,7 @@ class ASAlertController: UIViewController {
     
     private func setupUI() {
         view.backgroundColor = .black.withAlphaComponent(0.3)
-        alertView.setConfiguration(title: titleText, titleAlign: .center, titleSize: 24)
+        alertView.setTitle(title: titleText, titleAlign: .center, titleSize: 24)
         alertView.transform = CGAffineTransform(scaleX: 1.2, y: 1.2)
         alertView.backgroundColor = .asLightGray
         alertView.layer.borderWidth = 0

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/ASPanel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/ASPanel.swift
@@ -1,37 +1,45 @@
 import UIKit
 
 class ASPanel: UIView {
+    var panelColor: UIColor = .white {
+        didSet {
+            backgroundColor = panelColor
+        }
+    }
+
     init() {
         super.init(frame: .zero)
+        setupUI()
     }
-    
+
     required init?(coder: NSCoder) {
         super.init(coder: coder)
     }
-    
-    func setConfiguration(
+
+    func setTitle(
         title: String,
         titleAlign: NSTextAlignment,
         titleSize: CGFloat
     ) {
         backgroundColor = .asSystem
-        
+
         let label = UILabel()
         label.textColor = .asBlack
         label.text = title
         label.textAlignment = titleAlign
         label.font = UIFont.font(.dohyeon, ofSize: titleSize)
         addSubview(label)
-        
+
         label.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             label.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
             label.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -16),
             label.topAnchor.constraint(equalTo: topAnchor, constant: 16),
         ])
-        
+    }
+
+    func setupUI() {
         layer.cornerRadius = 12
-        
         layer.borderColor = UIColor.black.cgColor
         layer.borderWidth = 3
         setShadow()

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/ASPanel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/ASPanel.swift
@@ -1,7 +1,7 @@
 import UIKit
 
 class ASPanel: UIView {
-    var panelColor: UIColor = .white {
+    private var panelColor: UIColor = .asSystem {
         didSet {
             backgroundColor = panelColor
         }
@@ -16,13 +16,15 @@ class ASPanel: UIView {
         super.init(coder: coder)
     }
 
+    func updateBackgroundColor(_ color: UIColor) {
+        backgroundColor = color
+    }
+    
     func setTitle(
         title: String,
         titleAlign: NSTextAlignment,
         titleSize: CGFloat
     ) {
-        backgroundColor = .asSystem
-
         let label = UILabel()
         label.textColor = .asBlack
         label.text = title
@@ -38,7 +40,7 @@ class ASPanel: UIView {
         ])
     }
 
-    func setupUI() {
+    private func setupUI() {
         layer.cornerRadius = 12
         layer.borderColor = UIColor.black.cgColor
         layer.borderWidth = 3

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/AudioVisualizerView.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/AudioVisualizerView.swift
@@ -3,12 +3,11 @@ import UIKit
 import SwiftUI
 
 final class AudioVisualizerView: UIView {
-    // TODO: Button을 누르면 ViewModel에 존재하는 ASPlayer가 실행되고 Button의 이미지 변경
-    // + ViewModel에서 @Published로 가지고 있는 amplitude를 구독해 변경이 발생할 시, VC에서 updateWaveFormView 메서드 호출
-    private var startButton = UIButton()
+    private var playButton = UIButton()
     private var waveFormView = WaveFormView()
     private var customBackgroundColor: UIColor = .asMint
     private var cancellables = Set<AnyCancellable>()
+    var onPlayButtonTapped: ((_ isPlaying: Bool) -> Void)?
 
     init() {
         super.init(frame: .zero)
@@ -36,8 +35,11 @@ final class AudioVisualizerView: UIView {
     private func setupButton() {
         let config = UIImage.SymbolConfiguration(pointSize: 24, weight: .regular)
         let playImage = UIImage(systemName: "play.fill", withConfiguration: config)
-        startButton.setImage(playImage, for: .normal)
-        startButton.tintColor = UIColor.white
+        let stopImage = UIImage(systemName: "stop.fill", withConfiguration: config)
+        playButton.setImage(playImage, for: .normal)
+        playButton.setImage(stopImage, for: .selected)
+        playButton.tintColor = .white
+        playButton.adjustsImageWhenHighlighted = false
     }
 
     private func setupView() {
@@ -46,18 +48,18 @@ final class AudioVisualizerView: UIView {
     }
 
     private func addSubViews() {
-        addSubview(startButton)
-        startButton.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(playButton)
+        playButton.translatesAutoresizingMaskIntoConstraints = false
         addSubview(waveFormView)
         waveFormView.translatesAutoresizingMaskIntoConstraints = false
     }
 
     private func setupLayout() {
         NSLayoutConstraint.activate([
-            startButton.topAnchor.constraint(equalTo: topAnchor, constant: 16),
-            startButton.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -16),
-            startButton.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 12),
-            startButton.trailingAnchor.constraint(equalTo: waveFormView.leadingAnchor, constant: -12),
+            playButton.topAnchor.constraint(equalTo: topAnchor, constant: 16),
+            playButton.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -16),
+            playButton.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 12),
+            playButton.trailingAnchor.constraint(equalTo: waveFormView.leadingAnchor, constant: -12),
 
             waveFormView.topAnchor.constraint(equalTo: topAnchor, constant: 8),
             waveFormView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -8),

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/MusicPanel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/MusicPanel.swift
@@ -120,6 +120,7 @@ private final class ASMusicPlayer: UIView {
 
     func updateImage(with image: Data?) {
         if let image, !image.isEmpty {
+            backgroundImageView.layer.sublayers?.removeAll()
             backgroundImageView.image = UIImage(data: image)
         } else {
             let gradientLayer = makeGradientLayer()

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/MusicPanel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/MusicPanel.swift
@@ -1,0 +1,221 @@
+import ASContainer
+import ASEntity
+import ASRepository
+import Combine
+import UIKit
+
+final class MusicPanel: UIView {
+    private var music: Music?
+    private let panel = ASPanel()
+    private let player = ASMusicPlayer()
+    private let titleLabel = UILabel()
+    private let artistLabel = UILabel()
+    private var cancellables = Set<AnyCancellable>()
+    private let musicRepository: MusicRepositoryProtocol
+
+    init() {
+        musicRepository = DIContainer.shared.resolve(MusicRepositoryProtocol.self)
+        super.init(frame: .zero)
+        setupUI()
+        setupLayout()
+    }
+
+    @available(*, unavailable)
+    required init?(coder _: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func onPlayButtonTapped(completion: ((_ isPlaying: Bool) -> Void)?) {
+        player.onPlayButtonTapped = { isPlaying in
+            completion?(isPlaying)
+        }
+    }
+
+    func bind(
+        to dataSource: Published<Music?>.Publisher
+    ) {
+        dataSource
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] music in
+                self?.music = music
+                self?.getArtworkData()
+                self?.titleLabel.text = music?.title ?? "???"
+                self?.artistLabel.text = music?.artist ?? "????"
+                self?.setNeedsLayout()
+            }
+            .store(in: &cancellables)
+    }
+
+    private func setupUI() {
+        addSubview(panel)
+        addSubview(player)
+        addSubview(titleLabel)
+        addSubview(artistLabel)
+
+        panel.panelColor = .asSystem
+        titleLabel.font = .font(forTextStyle: .title3)
+        artistLabel.font = .font(forTextStyle: .title3)
+        titleLabel.textColor = .label
+        artistLabel.textColor = .secondaryLabel
+    }
+
+    private func setupLayout() {
+        panel.translatesAutoresizingMaskIntoConstraints = false
+        player.translatesAutoresizingMaskIntoConstraints = false
+        titleLabel.translatesAutoresizingMaskIntoConstraints = false
+        artistLabel.translatesAutoresizingMaskIntoConstraints = false
+
+        NSLayoutConstraint.activate([
+            panel.topAnchor.constraint(equalTo: topAnchor),
+            panel.bottomAnchor.constraint(equalTo: bottomAnchor),
+            panel.leadingAnchor.constraint(equalTo: leadingAnchor),
+            panel.trailingAnchor.constraint(equalTo: trailingAnchor),
+
+            player.topAnchor.constraint(equalTo: topAnchor, constant: 24),
+            player.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 24),
+            player.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -24),
+            player.bottomAnchor.constraint(equalTo: titleLabel.topAnchor, constant: -12),
+
+            titleLabel.centerXAnchor.constraint(equalTo: centerXAnchor),
+            artistLabel.centerXAnchor.constraint(equalTo: centerXAnchor),
+            artistLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 12),
+            artistLabel.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -24),
+        ])
+    }
+
+    private func getArtworkData() {
+        guard let artworkUrl = music?.artworkUrl else { return player.updateImage(with: nil) }
+        musicRepository.getMusicData(url: artworkUrl)
+            .receive(on: DispatchQueue.main)
+            .sink { completion in
+                switch completion {
+                    case .finished:
+                        break
+                    case let .failure(error):
+                        print(error.localizedDescription)
+                }
+            } receiveValue: { [weak self] artwork in
+                self?.player.updateImage(with: artwork)
+            }
+            .store(in: &cancellables)
+    }
+}
+
+private final class ASMusicPlayer: UIView {
+    private var backgroundImageView = UIImageView()
+    private var blurView = UIVisualEffectView()
+    private var playButton = UIButton()
+    var onPlayButtonTapped: ((_ isPlaying: Bool) -> Void)?
+
+    init() {
+        super.init(frame: .zero)
+        setupUI()
+        setupLayout()
+    }
+
+    @available(*, unavailable)
+    required init?(coder _: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func updateImage(with image: Data?) {
+        if let image, !image.isEmpty {
+            backgroundImageView.image = UIImage(data: image)
+        } else {
+            let gradientLayer = makeGradientLayer()
+            backgroundImageView.layer.addSublayer(gradientLayer)
+        }
+    }
+
+    private func setupUI() {
+        backgroundImageView.contentMode = .scaleAspectFill
+        backgroundImageView.clipsToBounds = true
+        backgroundImageView.layer.cornerRadius = 15
+        setupButton()
+        setupBlurView()
+        addSubview(backgroundImageView)
+        addSubview(blurView)
+        addSubview(playButton)
+    }
+
+    private func setupLayout() {
+        backgroundImageView.translatesAutoresizingMaskIntoConstraints = false
+        blurView.translatesAutoresizingMaskIntoConstraints = false
+        playButton.translatesAutoresizingMaskIntoConstraints = false
+
+        NSLayoutConstraint.activate([
+            backgroundImageView.topAnchor.constraint(equalTo: topAnchor),
+            backgroundImageView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            backgroundImageView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            backgroundImageView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            backgroundImageView.heightAnchor.constraint(equalTo: widthAnchor),
+
+            blurView.topAnchor.constraint(equalTo: topAnchor),
+            blurView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            blurView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            blurView.trailingAnchor.constraint(equalTo: trailingAnchor),
+
+            playButton.leadingAnchor.constraint(equalTo: backgroundImageView.leadingAnchor, constant: 92),
+            playButton.trailingAnchor.constraint(equalTo: backgroundImageView.trailingAnchor, constant: -92),
+            playButton.centerYAnchor.constraint(equalTo: backgroundImageView.centerYAnchor),
+        ])
+    }
+
+    private func didButtonTapped() {
+        playButton.isSelected.toggle()
+        onPlayButtonTapped?(!playButton.isSelected)
+    }
+
+    private func makeGradientLayer() -> CAGradientLayer {
+        let gradientLayer = CAGradientLayer()
+        let colors: [CGColor] = [
+            UIColor.asOrange.cgColor,
+            UIColor.asYellow.cgColor,
+            UIColor.asGreen.cgColor,
+        ]
+        gradientLayer.frame = backgroundImageView.bounds
+        gradientLayer.colors = colors
+        gradientLayer.startPoint = CGPoint(x: 1.0, y: 0.0)
+        gradientLayer.endPoint = CGPoint(x: 0.0, y: 1.0)
+        return gradientLayer
+    }
+
+    private func setupButton() {
+        let configuration = UIImage.SymbolConfiguration(pointSize: 60)
+        let playImage = UIImage(systemName: "play.fill", withConfiguration: configuration)
+        let stopImage = UIImage(systemName: "stop.fill", withConfiguration: configuration)
+        playButton.setImage(playImage, for: .normal)
+        playButton.setImage(stopImage, for: .selected)
+        playButton.tintColor = .white
+        playButton.adjustsImageWhenHighlighted = false
+        playButton.addAction(UIAction { [weak self] _ in
+            self?.didButtonTapped()
+        }, for: .touchUpInside)
+        playButton.addAction(UIAction { [weak self] _ in
+            self?.buttonTouchDown()
+        }, for: .touchDown)
+        playButton.addAction(UIAction { [weak self] _ in
+            self?.buttonTouchUp()
+        }, for: [.touchUpInside, .touchCancel, .touchUpOutside])
+    }
+
+    private func buttonTouchDown() {
+        UIView.animate(withDuration: 0.1, delay: 0, options: .curveEaseOut) {
+            self.playButton.transform = CGAffineTransform(scaleX: 0.9, y: 0.9)
+        }
+    }
+
+    private func buttonTouchUp() {
+        UIView.animate(withDuration: 0.1, delay: 0, options: .curveEaseInOut) {
+            self.playButton.transform = .identity
+        }
+    }
+
+    private func setupBlurView() {
+        let blurEffect = UIBlurEffect(style: .systemUltraThinMaterialDark)
+        blurView = UIVisualEffectView(effect: blurEffect)
+        blurView.layer.cornerRadius = 15
+        blurView.clipsToBounds = true
+        blurView.alpha = 0.6
+    }
+}

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/SubmissionStatusView.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/SubmissionStatusView.swift
@@ -3,13 +3,12 @@ import UIKit
 
 final class SubmissionStatusView: UIStackView {
     let label = UILabel()
+    
     private var cancellables = Set<AnyCancellable>()
 
     init() {
         super.init(frame: .zero)
-        setupStack()
-        setupImage()
-        setupLabel()
+        setupUI()
     }
 
     @available(*, unavailable)
@@ -18,7 +17,19 @@ final class SubmissionStatusView: UIStackView {
     }
 
     override var intrinsicContentSize: CGSize {
-        return CGSize(width: 120, height: 48)
+        return CGSize(width: 64, height: 30)
+    }
+
+    private func setupUI() {
+        backgroundColor = .asSystem
+        layer.cornerRadius = intrinsicContentSize.height / 2
+        clipsToBounds = true
+        layer.borderColor = UIColor.label.cgColor
+        layer.borderWidth = 2.5
+        
+        setupStack()
+        setupImage()
+        setupLabel()
     }
 
     func bind(
@@ -27,30 +38,33 @@ final class SubmissionStatusView: UIStackView {
         dataSource
             .receive(on: DispatchQueue.main)
             .sink { [weak self] status in
-                self?.label.text = "\(status.submits) / \(status.total)"
+                self?.label.text = "\(status.submits)/\(status.total)"
             }
             .store(in: &cancellables)
     }
-
-    func setupStack() {
+    
+    private func setupStack() {
         axis = .horizontal
         alignment = .center
-        spacing = 16
+        spacing = 2
+        isLayoutMarginsRelativeArrangement = true
+        layoutMargins = UIEdgeInsets(top: 0, left: 10, bottom: 0, right: 8)
     }
 
-    func setupLabel() {
-        label.font = .font(forTextStyle: .largeTitle)
-        addArrangedSubview(label)
-    }
+    private func setupImage() {
+        let configuration = UIImage.SymbolConfiguration(pointSize: 20, weight: .bold)
+        let image = UIImage(systemName: "checkmark", withConfiguration: configuration)
 
-    func setupImage() {
-        let image = UIImage(systemName: "checkmark.square.fill")
         let imageView = UIImageView(image: image)
-        imageView.tintColor = .asGreen
-        addArrangedSubview(imageView)
-
+        imageView.tintColor = .label
+        imageView.contentMode = .scaleAspectFit
         imageView.translatesAutoresizingMaskIntoConstraints = false
-        imageView.widthAnchor.constraint(equalToConstant: 48).isActive = true
-        imageView.heightAnchor.constraint(equalToConstant: 48).isActive = true
+        imageView.widthAnchor.constraint(equalToConstant: 16).isActive = true
+        addArrangedSubview(imageView)
+    }
+    
+    private func setupLabel() {
+        label.font = .font(forTextStyle: .body)
+        addArrangedSubview(label)
     }
 }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Utils/AudioHelper.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Utils/AudioHelper.swift
@@ -10,11 +10,11 @@ actor AudioHelper {
     private var player: ASAudioPlayer?
     private var timer: Timer?
     private let amplitudeSubject = PassthroughSubject<Float, Never>()
-    private init() {}
-
-    func amplitudePubisher() -> AnyPublisher<Float, Never> {
+    var amplitudePublisher: AnyPublisher<Float, Never> {
         return amplitudeSubject.eraseToAnyPublisher()
     }
+    
+    private init() {}
 
     func isRecording() async -> Bool {
         guard let recorder else { return false }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Utils/AudioHelper.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Utils/AudioHelper.swift
@@ -62,7 +62,7 @@ actor AudioHelper {
         }
         RunLoop.main.add(timer!, forMode: .common)
     }
-    
+
     private func calculateRecorderAmplitude() async {
         await recorder?.updateMeters()
         guard let averagePower = await recorder?.getAveragePower() else { return }
@@ -73,6 +73,7 @@ actor AudioHelper {
 
     func startPlaying(file: Data?, playType: PlayType = .full) async {
         guard let file else { return }
+        if let player = player, await player.isPlaying() { await stopPlaying() }
         makePlayer()
         await player?.setOnPlaybackFinished { [weak self] in
             await self?.stopPlaying()
@@ -82,10 +83,13 @@ actor AudioHelper {
 
     func stopPlaying() async {
         await player?.stopPlaying()
+        player = nil
     }
 
     private func stopRecording() async -> Data? {
-        await recorder?.stopRecording()
+        let recordedData = await recorder?.stopRecording()
+        recorder = nil
+        return recordedData
     }
 
     private func makeRecorder() {

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Humming/HummingView.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Humming/HummingView.swift
@@ -35,9 +35,6 @@ final class HummingViewController: UIViewController {
         musicPanel.bind(to: vm.$music)
         hummingPanel.bind(to: vm.$recorderAmplitude)
         submitButton.bind(to: vm.$humming)
-        hummingPanel.onPlayButtonTapped = { [weak self] isPlaying in
-            self?.vm.togglePlayPause(of: .humming, isPlaying: isPlaying)
-        }
     }
 
     private func setupUI() {

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Humming/HummingView.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Humming/HummingView.swift
@@ -38,6 +38,9 @@ final class HummingViewController: UIViewController {
         musicPanel.onPlayButtonTapped { [weak self] isPlaying in
             self?.vm.togglePlayPause(of: .preview, isPlaying: isPlaying)
         }
+        hummingPanel.onPlayButtonTapped = { [weak self] isPlaying in
+            self?.vm.togglePlayPause(of: .humming, isPlaying: isPlaying)
+        }
     }
 
     private func setupUI() {

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Humming/HummingView.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Humming/HummingView.swift
@@ -35,9 +35,6 @@ final class HummingViewController: UIViewController {
         musicPanel.bind(to: vm.$music)
         hummingPanel.bind(to: vm.$recorderAmplitude)
         submitButton.bind(to: vm.$humming)
-        musicPanel.onPlayButtonTapped { [weak self] isPlaying in
-            self?.vm.togglePlayPause(of: .preview, isPlaying: isPlaying)
-        }
         hummingPanel.onPlayButtonTapped = { [weak self] isPlaying in
             self?.vm.togglePlayPause(of: .humming, isPlaying: isPlaying)
         }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Humming/HummingView.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Humming/HummingView.swift
@@ -6,7 +6,7 @@ final class HummingViewController: UIViewController {
     private var progressBar = ProgressBar()
     private var guideLabel = GuideLabel()
     private var musicPanel = MusicPanel()
-    private var hummingPanel = RecordingPanel()
+    private var hummingPanel = RecordingPanel(.asYellow)
     private var recordButton = ASButton()
     private var submitButton = ASButton()
     private var submissionStatus = SubmissionStatusView()
@@ -42,7 +42,6 @@ final class HummingViewController: UIViewController {
 
     private func setupUI() {
         guideLabel.setText("노래를 따라해 보세요!")
-        hummingPanel.changeBackgroundColor(color: .asYellow)
         recordButton.setConfiguration(title: "녹음하기", backgroundColor: .asLightRed)
         recordButton.addAction(UIAction { [weak self] _ in
             self?.vm.startRecording()

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Humming/HummingView.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Humming/HummingView.swift
@@ -6,7 +6,7 @@ final class HummingViewController: UIViewController {
     private var progressBar = ProgressBar()
     private var guideLabel = GuideLabel()
     private var musicPanel = MusicPanel()
-    private var hummingPanel = AudioVisualizerView()
+    private var hummingPanel = RecordingPanel()
     private var recordButton = ASButton()
     private var submitButton = ASButton()
     private var submissionStatus = SubmissionStatusView()
@@ -33,8 +33,11 @@ final class HummingViewController: UIViewController {
         submissionStatus.bind(to: vm.$submissionStatus)
         progressBar.bind(to: vm.$dueTime)
         musicPanel.bind(to: vm.$music)
-        hummingPanel.bind(to: vm.$recorderAmplitude)
-        submitButton.bind(to: vm.$humming)
+        hummingPanel.bind(to: vm.$isRecording)
+        hummingPanel.onRecordingFinished = { [weak self] recordedData in
+            self?.vm.updateRecordedData(with: recordedData)
+        }
+        submitButton.bind(to: vm.$recordedData)
     }
 
     private func setupUI() {

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Humming/HummingView.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Humming/HummingView.swift
@@ -36,6 +36,7 @@ final class HummingViewController: UIViewController {
         hummingPanel.bind(to: vm.$recorderAmplitude)
         submitButton.bind(to: vm.$humming)
         musicPanel.onPlayButtonTapped { [weak self] isPlaying in
+            self?.vm.togglePlayPause(of: .preview, isPlaying: isPlaying)
         }
     }
 

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Humming/HummingView.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Humming/HummingView.swift
@@ -6,9 +6,10 @@ final class HummingViewController: UIViewController {
     private var progressBar = ProgressBar()
     private var guideLabel = GuideLabel()
     private var hummingPanel = AudioVisualizerView()
-    private var recordButton = RecordButton()
+    private var recordButton = ASButton()
     private var submitButton = ASButton()
     private var submissionStatus = SubmissionStatusView()
+    private var buttonStack = UIStackView()
     private let vm: HummingViewModel
 
     init(vm: HummingViewModel) {
@@ -37,8 +38,9 @@ final class HummingViewController: UIViewController {
     private func setupUI() {
         guideLabel.setText("노래를 따라해 보세요!")
         hummingPanel.changeBackgroundColor(color: .asYellow)
-        recordButton.addAction(UIAction {
-            [weak self] _ in self?.vm.startRecording()
+        recordButton.setConfiguration(title: "녹음하기", backgroundColor: .asLightRed)
+        recordButton.addAction(UIAction { [weak self] _ in
+            self?.vm.startRecording()
         },
         for: .touchUpInside)
         submitButton.setConfiguration(title: "녹음 완료", backgroundColor: .asLightGray)
@@ -57,24 +59,26 @@ final class HummingViewController: UIViewController {
                 )
                 let vc = RehummingViewController(vm: vm)
                 self?.navigationController?.pushViewController(vc, animated: true)
-        }, for: .touchUpInside)
+            }, for: .touchUpInside
+        )
         submitButton.isEnabled = false
+        buttonStack.axis = .horizontal
+        buttonStack.spacing = 16
+        buttonStack.addArrangedSubview(recordButton)
+        buttonStack.addArrangedSubview(submitButton)
         view.backgroundColor = .asLightGray
         view.addSubview(progressBar)
         view.addSubview(guideLabel)
         view.addSubview(hummingPanel)
-        view.addSubview(recordButton)
-        view.addSubview(submitButton)
-        view.addSubview(submissionStatus)
+        view.addSubview(buttonStack)
     }
 
     private func setupLayout() {
         progressBar.translatesAutoresizingMaskIntoConstraints = false
         guideLabel.translatesAutoresizingMaskIntoConstraints = false
         hummingPanel.translatesAutoresizingMaskIntoConstraints = false
-        recordButton.translatesAutoresizingMaskIntoConstraints = false
-        submitButton.translatesAutoresizingMaskIntoConstraints = false
         submissionStatus.translatesAutoresizingMaskIntoConstraints = false
+        buttonStack.translatesAutoresizingMaskIntoConstraints = false
 
         NSLayoutConstraint.activate([
             progressBar.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
@@ -90,16 +94,11 @@ final class HummingViewController: UIViewController {
             hummingPanel.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -16),
             hummingPanel.heightAnchor.constraint(equalToConstant: 64),
 
-            recordButton.topAnchor.constraint(equalTo: hummingPanel.bottomAnchor, constant: 68),
-            recordButton.centerXAnchor.constraint(equalTo: view.centerXAnchor),
 
-            submitButton.bottomAnchor.constraint(equalTo: submissionStatus.topAnchor, constant: -24),
-            submitButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 16),
-            submitButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -16),
-            submitButton.heightAnchor.constraint(equalToConstant: 64),
-
-            submissionStatus.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: 0),
-            submissionStatus.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            buttonStack.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -24),
+            buttonStack.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 16),
+            buttonStack.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -16),
+            buttonStack.heightAnchor.constraint(equalToConstant: 64),
         ])
     }
 }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Humming/HummingView.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Humming/HummingView.swift
@@ -76,6 +76,7 @@ final class HummingViewController: UIViewController {
         view.addSubview(musicPanel)
         view.addSubview(hummingPanel)
         view.addSubview(buttonStack)
+        view.addSubview(submissionStatus)
     }
 
     private func setupLayout() {
@@ -100,13 +101,16 @@ final class HummingViewController: UIViewController {
             musicPanel.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -48),
 
             hummingPanel.topAnchor.constraint(equalTo: musicPanel.bottomAnchor, constant: 36),
-            hummingPanel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 16),
-            hummingPanel.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -16),
+            hummingPanel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 24),
+            hummingPanel.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -24),
             hummingPanel.heightAnchor.constraint(equalToConstant: 84),
 
+            submissionStatus.topAnchor.constraint(equalTo: buttonStack.topAnchor, constant: -16),
+            submissionStatus.trailingAnchor.constraint(equalTo: buttonStack.trailingAnchor, constant: 16),
+            
             buttonStack.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -24),
-            buttonStack.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 16),
-            buttonStack.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -16),
+            buttonStack.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 24),
+            buttonStack.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -24),
             buttonStack.heightAnchor.constraint(equalToConstant: 64),
         ])
     }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Humming/HummingView.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Humming/HummingView.swift
@@ -5,6 +5,7 @@ import UIKit
 final class HummingViewController: UIViewController {
     private var progressBar = ProgressBar()
     private var guideLabel = GuideLabel()
+    private var musicPanel = MusicPanel()
     private var hummingPanel = AudioVisualizerView()
     private var recordButton = ASButton()
     private var submitButton = ASButton()
@@ -31,8 +32,11 @@ final class HummingViewController: UIViewController {
     private func bindToComponents() {
         submissionStatus.bind(to: vm.$submissionStatus)
         progressBar.bind(to: vm.$dueTime)
+        musicPanel.bind(to: vm.$music)
         hummingPanel.bind(to: vm.$recorderAmplitude)
         submitButton.bind(to: vm.$humming)
+        musicPanel.onPlayButtonTapped { [weak self] isPlaying in
+        }
     }
 
     private func setupUI() {
@@ -69,6 +73,7 @@ final class HummingViewController: UIViewController {
         view.backgroundColor = .asLightGray
         view.addSubview(progressBar)
         view.addSubview(guideLabel)
+        view.addSubview(musicPanel)
         view.addSubview(hummingPanel)
         view.addSubview(buttonStack)
     }
@@ -76,6 +81,7 @@ final class HummingViewController: UIViewController {
     private func setupLayout() {
         progressBar.translatesAutoresizingMaskIntoConstraints = false
         guideLabel.translatesAutoresizingMaskIntoConstraints = false
+        musicPanel.translatesAutoresizingMaskIntoConstraints = false
         hummingPanel.translatesAutoresizingMaskIntoConstraints = false
         submissionStatus.translatesAutoresizingMaskIntoConstraints = false
         buttonStack.translatesAutoresizingMaskIntoConstraints = false
@@ -89,11 +95,14 @@ final class HummingViewController: UIViewController {
             guideLabel.topAnchor.constraint(equalTo: progressBar.bottomAnchor, constant: 20),
             guideLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor),
 
-            hummingPanel.topAnchor.constraint(equalTo: guideLabel.bottomAnchor, constant: 68),
+            musicPanel.topAnchor.constraint(equalTo: guideLabel.bottomAnchor, constant: 20),
+            musicPanel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 48),
+            musicPanel.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -48),
+
+            hummingPanel.topAnchor.constraint(equalTo: musicPanel.bottomAnchor, constant: 36),
             hummingPanel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 16),
             hummingPanel.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -16),
-            hummingPanel.heightAnchor.constraint(equalToConstant: 64),
-
+            hummingPanel.heightAnchor.constraint(equalToConstant: 84),
 
             buttonStack.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -24),
             buttonStack.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 16),

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Humming/HummingView.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Humming/HummingView.swift
@@ -86,7 +86,7 @@ final class HummingViewController: UIViewController {
             progressBar.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             progressBar.heightAnchor.constraint(equalToConstant: 16),
 
-            guideLabel.topAnchor.constraint(equalTo: progressBar.bottomAnchor, constant: 56),
+            guideLabel.topAnchor.constraint(equalTo: progressBar.bottomAnchor, constant: 20),
             guideLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor),
 
             hummingPanel.topAnchor.constraint(equalTo: guideLabel.bottomAnchor, constant: 68),

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Humming/HummingViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Humming/HummingViewModel.swift
@@ -3,7 +3,7 @@ import ASRepository
 import Combine
 import Foundation
 
-final class HummingViewModel: ObservableObject, @unchecked Sendable {
+final class HummingViewModel: @unchecked Sendable {
     @Published public private(set) var dueTime: Date?
     @Published public private(set) var round: UInt8?
     @Published public private(set) var status: Status?

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Humming/HummingViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Humming/HummingViewModel.swift
@@ -9,7 +9,6 @@ final class HummingViewModel: ObservableObject, @unchecked Sendable {
     @Published public private(set) var status: Status?
     @Published public private(set) var submissionStatus: (submits: String, total: String) = ("0", "0")
     @Published public private(set) var music: Music?
-    @Published public private(set) var musicArtwork: Data?
     @Published public private(set) var musicPreview: Data?
     @Published public private(set) var humming: Data?
     @Published public private(set) var recorderAmplitude: Float = 0.0

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Humming/HummingViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Humming/HummingViewModel.swift
@@ -15,7 +15,7 @@ final class HummingViewModel: ObservableObject, @unchecked Sendable {
 
     private let gameStatusRepository: GameStatusRepositoryProtocol
     private let playersRepository: PlayersRepositoryProtocol
-    private var musicRepository: MusicRepositoryProtocol
+    private let musicRepository: MusicRepositoryProtocol
     private let answersRepository: AnswersRepositoryProtocol
     private let submitsRepository: SubmitsRepositoryProtocol
     private var cancellables: Set<AnyCancellable> = []

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Humming/HummingViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Humming/HummingViewModel.swift
@@ -8,21 +8,25 @@ final class HummingViewModel: ObservableObject, @unchecked Sendable {
     @Published public private(set) var round: UInt8?
     @Published public private(set) var status: Status?
     @Published public private(set) var submissionStatus: (submits: String, total: String) = ("0", "0")
+    @Published public private(set) var music: Music?
     @Published public private(set) var humming: Data?
     @Published public private(set) var recorderAmplitude: Float = 0.0
 
     private let gameStatusRepository: GameStatusRepositoryProtocol
     private let playersRepository: PlayersRepositoryProtocol
+    private var musicRepository: MusicRepositoryProtocol
     private let submitsRepository: SubmitsRepositoryProtocol
     private var cancellables: Set<AnyCancellable> = []
 
     public init(
         gameStatusRepository: GameStatusRepositoryProtocol,
         playersRepository: PlayersRepositoryProtocol,
+        musicRepository: MusicRepositoryProtocol,
         submitsRepository: SubmitsRepositoryProtocol
     ) {
         self.gameStatusRepository = gameStatusRepository
         self.playersRepository = playersRepository
+        self.musicRepository = musicRepository
         self.submitsRepository = submitsRepository
         bindGameStatus()
         bindSubmitStatus()

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Humming/HummingViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Humming/HummingViewModel.swift
@@ -33,6 +33,15 @@ final class HummingViewModel: ObservableObject, @unchecked Sendable {
         bindAmplitudeUpdates()
     }
 
+    func togglePlayPause(of type: AudioType, isPlaying: Bool = true) {
+        Task {
+            switch type {
+                case .humming:
+                    await AudioHelper.shared.startPlaying(file: humming)
+                case .preview:
+            }
+        }
+    }
     private func bindAmplitudeUpdates() {
         Task {
             await AudioHelper.shared.amplitudePubisher()
@@ -91,10 +100,7 @@ final class HummingViewModel: ObservableObject, @unchecked Sendable {
         }
     }
 
-    @MainActor
-    func startPlaying() {
-        Task {
-            await AudioHelper.shared.startPlaying(file: humming)
-        }
+    enum AudioType {
+        case preview, humming
     }
 }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/MusicPanel/MusicPanel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/MusicPanel/MusicPanel.swift
@@ -36,7 +36,7 @@ final class MusicPanel: UIView {
                     music: music,
                     musicRepository: self?.musicRepository
                 )
-                self?.observeViewModel()
+                self?.bindViewModel()
                 self?.titleLabel.text = music?.title ?? "???"
                 self?.artistLabel.text = music?.artist ?? "????"
             }
@@ -49,7 +49,7 @@ final class MusicPanel: UIView {
         }
     }
 
-    private func observeViewModel() {
+    private func bindViewModel() {
         vm?.$artwork
             .receive(on: DispatchQueue.main)
             .sink { [weak self] artwork in

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/MusicPanel/MusicPanel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/MusicPanel/MusicPanel.swift
@@ -53,7 +53,6 @@ final class MusicPanel: UIView {
         vm?.$artwork
             .receive(on: DispatchQueue.main)
             .sink { [weak self] artwork in
-                print("artwork changed")
                 self?.player.updateImage(with: artwork)
             }
             .store(in: &cancellables)

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/MusicPanel/MusicPanel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/MusicPanel/MusicPanel.swift
@@ -64,7 +64,7 @@ final class MusicPanel: UIView {
         addSubview(titleLabel)
         addSubview(artistLabel)
 
-        panel.panelColor = .asSystem
+        panel.updateBackgroundColor(.asSystem)
         titleLabel.font = .font(forTextStyle: .title3)
         artistLabel.font = .font(forTextStyle: .title3)
         titleLabel.textColor = .label

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/MusicPanel/MusicPanel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/MusicPanel/MusicPanel.swift
@@ -18,7 +18,7 @@ final class MusicPanel: UIView {
         super.init(frame: .zero)
         setupUI()
         setupLayout()
-        setupAction()
+        bindWithPlayer()
     }
 
     @available(*, unavailable)
@@ -32,15 +32,18 @@ final class MusicPanel: UIView {
         dataSource
             .receive(on: DispatchQueue.main)
             .sink { [weak self] music in
-                self?.vm = MusicPanelViewModel(music: music, musicRepository: self?.musicRepository)
+                self?.vm = MusicPanelViewModel(
+                    music: music,
+                    musicRepository: self?.musicRepository
+                )
+                self?.observeViewModel()
                 self?.titleLabel.text = music?.title ?? "???"
                 self?.artistLabel.text = music?.artist ?? "????"
-//                self?.setNeedsLayout()
             }
             .store(in: &cancellables)
     }
 
-    private func setupAction() {
+    private func bindWithPlayer() {
         player.onPlayButtonTapped = { [weak self] isPlaying in
             self?.vm?.togglePlayPause(isPlaying: isPlaying)
         }
@@ -50,12 +53,7 @@ final class MusicPanel: UIView {
         vm?.$artwork
             .receive(on: DispatchQueue.main)
             .sink { [weak self] artwork in
-                self?.player.updateImage(with: artwork)
-            }
-            .store(in: &cancellables)
-        vm?.$preview
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] artwork in
+                print("artwork changed")
                 self?.player.updateImage(with: artwork)
             }
             .store(in: &cancellables)

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/MusicPanel/MusicPanelViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/MusicPanel/MusicPanelViewModel.swift
@@ -2,6 +2,7 @@ import Foundation
 import ASEntity
 import Combine
 import ASRepository
+
 final class MusicPanelViewModel {
     @Published var music: Music?
     @Published var artwork: Data?

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/MusicPanel/MusicPanelViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/MusicPanel/MusicPanelViewModel.swift
@@ -1,0 +1,62 @@
+import Foundation
+import ASEntity
+import Combine
+import ASRepository
+
+final class MusicPanelViewModel {
+    @Published var music: Music?
+    @Published var artwork: Data?
+    @Published var preview: Data?
+    private let musicRepository: MusicRepositoryProtocol?
+    private var cancellables = Set<AnyCancellable>()
+
+    init(music: Music?, musicRepository: MusicRepositoryProtocol?) {
+        self.music = music
+        self.musicRepository = musicRepository
+        getPreviewData()
+        getArtworkData()
+    }
+
+    private func getPreviewData() {
+        guard let previewUrl = music?.previewUrl else { return }
+        musicRepository?.getMusicData(url: previewUrl)
+            .receive(on: DispatchQueue.main)
+            .sink { completion in
+                switch completion {
+                    case .finished:
+                        break
+                    case let .failure(error):
+                        print(error.localizedDescription)
+                }
+            } receiveValue: { [weak self] preview in
+                self?.preview = preview
+            }
+            .store(in: &cancellables)
+    }
+
+    private func getArtworkData() {
+        guard let artworkUrl = music?.artworkUrl else { return }
+        musicRepository?.getMusicData(url: artworkUrl)
+            .receive(on: DispatchQueue.main)
+            .sink { completion in
+                switch completion {
+                    case .finished:
+                        break
+                    case let .failure(error):
+                        print(error.localizedDescription)
+                }
+            } receiveValue: { [weak self] artwork in
+                self?.artwork = artwork
+            }
+            .store(in: &cancellables)
+    }
+
+    @MainActor
+    func togglePlayPause(isPlaying: Bool = true) {
+        Task {
+            isPlaying ?
+                await AudioHelper.shared.stopPlaying() :
+                await AudioHelper.shared.startPlaying(file: preview)
+        }
+    }
+}

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/MusicPanel/MusicPanelViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/MusicPanel/MusicPanelViewModel.swift
@@ -2,7 +2,6 @@ import Foundation
 import ASEntity
 import Combine
 import ASRepository
-
 final class MusicPanelViewModel {
     @Published var music: Music?
     @Published var artwork: Data?

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Onboarding/OnboardingViewController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Onboarding/OnboardingViewController.swift
@@ -159,7 +159,7 @@ final class OnboardingViewController: UIViewController {
             systemImageName: "",
             title: Constants.joinButtonTitle,
             backgroundColor: .asMint)
-        nickNamePanel.setConfiguration(
+        nickNamePanel.setTitle(
             title: Constants.nickNameTitle,
             titleAlign: .left,
             titleSize: 24)

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/RecordingPanel/RecordingPanel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/RecordingPanel/RecordingPanel.swift
@@ -14,7 +14,7 @@ final class RecordingPanel: UIView {
         setupButton()
         setupUI()
         setupLayout()
-        observeViewModel()
+        bindViewModel()
     }
 
     required init?(coder: NSCoder) {
@@ -28,7 +28,7 @@ final class RecordingPanel: UIView {
         customBackgroundColor = color
     }
 
-    private func observeViewModel() {
+    private func bindViewModel() {
         vm.$recordedData
             .filter { $0 != nil }
             .receive(on: DispatchQueue.main)

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/RecordingPanel/RecordingPanel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/RecordingPanel/RecordingPanel.swift
@@ -21,11 +21,22 @@ final class RecordingPanel: UIView {
     required init?(coder: NSCoder) {
         customBackgroundColor = .asMint
         super.init(coder: coder)
-        setupButton()
         setupUI()
         setupLayout()
+        setupButton()
     }
 
+    func bind(
+        to dataSource: Published<Bool>.Publisher
+    ) {
+        dataSource
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] isRecording in
+                if isRecording {
+                    self?.vm.startRecording()
+                }
+            }
+            .store(in: &cancellables)
     }
 
     private func bindViewModel() {
@@ -83,27 +94,15 @@ final class RecordingPanel: UIView {
         ])
     }
 
-    func bind(
-        to dataSource: Published<Bool>.Publisher
-    ) {
-        dataSource
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] isRecording in
-                if isRecording {
-                    self?.vm.startRecording()
-                }
-            }
-            .store(in: &cancellables)
-
-    func updateWaveForm(amplitude: CGFloat) {
+    private func updateWaveForm(amplitude: CGFloat) {
         waveFormView.updateVisualizerView(with: amplitude)
     }
 
-    func stopWaveForm() {
+    private func stopWaveForm() {
         waveFormView.removeVisualizerCircles()
     }
 
-    func reset() {
+    private func reset() {
         waveFormView.removeVisualizerCircles()
     }
 }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/RecordingPanel/RecordingPanel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/RecordingPanel/RecordingPanel.swift
@@ -1,0 +1,207 @@
+import Combine
+import UIKit
+
+final class RecordingPanel: UIView {
+    private var playButton = UIButton()
+    private var waveFormView = WaveForm()
+    private var customBackgroundColor: UIColor = .asMint
+    private var cancellables = Set<AnyCancellable>()
+    private let vm = RecordingPanelViewModel()
+    var onRecordingFinished: ((Data) -> Void)?
+
+    init() {
+        super.init(frame: .zero)
+        setupButton()
+        setupUI()
+        setupLayout()
+        observeViewModel()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setupButton()
+        setupUI()
+        setupLayout()
+    }
+
+    func changeBackgroundColor(color: UIColor) {
+        customBackgroundColor = color
+    }
+
+    private func observeViewModel() {
+        vm.$recordedData
+            .filter { $0 != nil }
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] recordedData in
+                self?.onRecordingFinished?(recordedData ?? Data())
+            }
+            .store(in: &cancellables)
+        vm.$recorderAmplitude
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] amplitude in
+                self?.updateWaveForm(amplitude: CGFloat(amplitude))
+            }
+            .store(in: &cancellables)
+    }
+
+    private func setupButton() {
+        let config = UIImage.SymbolConfiguration(pointSize: 24, weight: .regular)
+        let playImage = UIImage(systemName: "play.fill", withConfiguration: config)
+        let stopImage = UIImage(systemName: "stop.fill", withConfiguration: config)
+        playButton.setImage(playImage, for: .normal)
+        playButton.setImage(stopImage, for: .selected)
+        playButton.tintColor = .white
+        playButton.adjustsImageWhenHighlighted = false
+        playButton.addAction(UIAction { [weak self] _ in
+            self?.didButtonTapped()
+        }, for: .touchUpInside)
+    }
+
+    private func didButtonTapped() {
+        playButton.isSelected.toggle()
+    }
+
+    private func setupUI() {
+        layer.cornerRadius = 12
+        layer.backgroundColor = customBackgroundColor.cgColor
+        addSubview(playButton)
+        addSubview(waveFormView)
+    }
+
+    private func setupLayout() {
+        playButton.translatesAutoresizingMaskIntoConstraints = false
+        waveFormView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            playButton.topAnchor.constraint(equalTo: topAnchor, constant: 16),
+            playButton.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -16),
+            playButton.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 12),
+            playButton.trailingAnchor.constraint(equalTo: waveFormView.leadingAnchor, constant: -12),
+
+            waveFormView.topAnchor.constraint(equalTo: topAnchor, constant: 8),
+            waveFormView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -8),
+            waveFormView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -12),
+        ])
+    }
+
+    func bind(
+        to dataSource: Published<Bool>.Publisher
+    ) {
+        dataSource
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] isRecording in
+                if isRecording {
+                    self?.vm.startRecording()
+                }
+            }
+            .store(in: &cancellables)
+    }
+
+    func updateWaveForm(amplitude: CGFloat) {
+        waveFormView.updateVisualizerView(with: amplitude)
+    }
+
+    func stopWaveForm() {
+        waveFormView.removeVisualizerCircles()
+    }
+
+    func reset() {
+        waveFormView.removeVisualizerCircles()
+    }
+}
+
+private final class WaveForm: UIView {
+    var columnWidth: CGFloat?
+    var columns: [CAShapeLayer] = []
+    var amplitudesHistory: [CGFloat] = []
+    let numOfColumns: Int
+
+    override class func awakeFromNib() {
+        super.awakeFromNib()
+    }
+
+    init(numOfColumns: Int = 43) {
+        self.numOfColumns = numOfColumns
+        super.init(frame: .zero)
+    }
+
+    required init?(coder: NSCoder) {
+        numOfColumns = 43
+        super.init(coder: coder)
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        drawVisualizerCircles()
+    }
+
+    /// 파형의 기본 틀을 그립니다.
+    func drawVisualizerCircles() {
+        amplitudesHistory = Array(repeating: 0, count: numOfColumns)
+        let diameter = bounds.width / CGFloat(2 * numOfColumns + 1)
+        columnWidth = diameter
+        let startingPointY = bounds.midY - diameter / 2
+        var startingPointX = bounds.minX + diameter
+
+        for _ in 0 ..< numOfColumns {
+            let circleOrigin = CGPoint(x: startingPointX, y: startingPointY)
+            let circleSize = CGSize(width: diameter, height: diameter)
+            let circle = UIBezierPath(roundedRect: CGRect(origin: circleOrigin, size: circleSize), cornerRadius: diameter / 2)
+
+            let circleLayer = CAShapeLayer()
+            circleLayer.path = circle.cgPath
+            circleLayer.fillColor = UIColor.asShadow.cgColor
+
+            layer.addSublayer(circleLayer)
+            columns.append(circleLayer)
+            startingPointX += 2 * diameter
+        }
+    }
+
+    /// 그려진 파형을 모두 삭제합니다.
+    fileprivate func removeVisualizerCircles() {
+        for column in columns {
+            column.removeFromSuperlayer()
+        }
+
+        columns.removeAll()
+    }
+
+    private func computeNewPath(for layer: CAShapeLayer, with amplitude: CGFloat) -> CGPath {
+        let width = columnWidth ?? 8.0
+        let maxHeightGain = bounds.height - 3 * width
+        let heightGain = maxHeightGain * amplitude
+        let newHeight = width + heightGain
+        let newOrigin = CGPoint(x: layer.path?.boundingBox.origin.x ?? 0,
+                                y: (layer.superlayer?.bounds.midY ?? 0) - (newHeight / 2))
+        let newSize = CGSize(width: width, height: newHeight)
+
+        return UIBezierPath(roundedRect: CGRect(origin: newOrigin, size: newSize), cornerRadius: width / 2).cgPath
+    }
+
+    /// 오른쪽에서 파형이 시작
+    fileprivate func updateVisualizerView(with amplitude: CGFloat) {
+        guard columns.count == numOfColumns else { return }
+        amplitudesHistory.append(amplitude)
+        amplitudesHistory.removeFirst()
+        for i in 0 ..< columns.count {
+            columns[i].path = computeNewPath(for: columns[i], with: amplitudesHistory[i])
+            if amplitudesHistory[i] != 0 {
+                columns[i].fillColor = UIColor.white.cgColor
+            }
+        }
+    }
+
+    /// 왼쪽에서 파형이 시작
+    fileprivate func reverseUpdateVisualizerView(with amplitude: CGFloat) {
+        guard columns.count == numOfColumns else { return }
+        amplitudesHistory.insert(amplitude, at: 0)
+        amplitudesHistory.removeLast()
+
+        for i in 0 ..< columns.count {
+            columns[i].path = computeNewPath(for: columns[i], with: amplitudesHistory[i])
+            if amplitudesHistory[i] != 0 {
+                columns[i].fillColor = UIColor.white.cgColor
+            }
+        }
+    }
+}

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/RecordingPanel/RecordingPanel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/RecordingPanel/RecordingPanel.swift
@@ -53,6 +53,12 @@ final class RecordingPanel: UIView {
                 self?.updateWaveForm(amplitude: CGFloat(amplitude))
             }
             .store(in: &cancellables)
+        vm.$isPlaying
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] isPlaying in
+                self?.playButton.isSelected = isPlaying
+            }
+            .store(in: &cancellables)
     }
 
     private func setupButton() {
@@ -69,7 +75,7 @@ final class RecordingPanel: UIView {
     }
 
     private func didButtonTapped() {
-        playButton.isSelected.toggle()
+        vm.togglePlayPause()
     }
 
     private func setupUI() {

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/RecordingPanel/RecordingPanel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/RecordingPanel/RecordingPanel.swift
@@ -4,12 +4,13 @@ import UIKit
 final class RecordingPanel: UIView {
     private var playButton = UIButton()
     private var waveFormView = WaveForm()
-    private var customBackgroundColor: UIColor = .asMint
+    private var customBackgroundColor: UIColor
     private var cancellables = Set<AnyCancellable>()
     private let vm = RecordingPanelViewModel()
     var onRecordingFinished: ((Data) -> Void)?
 
-    init() {
+    init(_ color: UIColor = .asMint) {
+        customBackgroundColor = color
         super.init(frame: .zero)
         setupButton()
         setupUI()
@@ -18,14 +19,13 @@ final class RecordingPanel: UIView {
     }
 
     required init?(coder: NSCoder) {
+        customBackgroundColor = .asMint
         super.init(coder: coder)
         setupButton()
         setupUI()
         setupLayout()
     }
 
-    func changeBackgroundColor(color: UIColor) {
-        customBackgroundColor = color
     }
 
     private func bindViewModel() {
@@ -94,7 +94,6 @@ final class RecordingPanel: UIView {
                 }
             }
             .store(in: &cancellables)
-    }
 
     func updateWaveForm(amplitude: CGFloat) {
         waveFormView.updateVisualizerView(with: amplitude)

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/RecordingPanel/RecordingPanelViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/RecordingPanel/RecordingPanelViewModel.swift
@@ -12,7 +12,7 @@ final class RecordingPanelViewModel: @unchecked Sendable {
 
     private func bindAmplitudeUpdates() {
         Task {
-            await AudioHelper.shared.amplitudePubisher()
+            await AudioHelper.shared.amplitudePublisher
                 .receive(on: DispatchQueue.main)
                 .sink { [weak self] newAmplitude in
                     guard let self = self else { return }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/RecordingPanel/RecordingPanelViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/RecordingPanel/RecordingPanelViewModel.swift
@@ -1,0 +1,41 @@
+import Combine
+import Foundation
+
+final class RecordingPanelViewModel: @unchecked Sendable {
+    @Published var recordedData: Data?
+    @Published public private(set) var recorderAmplitude: Float = 0.0
+    private var cancellables = Set<AnyCancellable>()
+    
+    init(){
+        bindAmplitudeUpdates()
+    }
+
+    private func bindAmplitudeUpdates() {
+        Task {
+            await AudioHelper.shared.amplitudePubisher()
+                .receive(on: DispatchQueue.main)
+                .sink { [weak self] newAmplitude in
+                    guard let self = self else { return }
+                    self.recorderAmplitude = newAmplitude
+                }
+                .store(in: &self.cancellables)
+        }
+    }
+
+    @MainActor
+    func startRecording() {
+        Task {
+            let data = await AudioHelper.shared.startRecording()
+            recordedData = data
+        }
+    }
+    
+    @MainActor
+    func togglePlayPause(isPlaying: Bool = true) {
+        Task {
+            isPlaying ?
+                await AudioHelper.shared.stopPlaying() :
+                await AudioHelper.shared.startPlaying(file: recordedData)
+        }
+    }
+}

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SelectMusic/SelectMusicViewController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SelectMusic/SelectMusicViewController.swift
@@ -65,11 +65,15 @@ class SelectMusicViewController: UIViewController {
             self?.selectMusicViewModel.stopMusic()
             let gameStatusRepository = DIContainer.shared.resolve(GameStatusRepositoryProtocol.self)
             let playersRepository = DIContainer.shared.resolve(PlayersRepositoryProtocol.self)
+            let musicRepository = DIContainer.shared.resolve(MusicRepositoryProtocol.self)
+            let answersRepository = DIContainer.shared.resolve(AnswersRepositoryProtocol.self)
             let submitsRepository = DIContainer.shared.resolve(SubmitsRepositoryProtocol.self)
             
             let hummingViewModel = HummingViewModel(
                 gameStatusRepository: gameStatusRepository,
                 playersRepository: playersRepository,
+                musicRepository: musicRepository,
+                answersRepository: answersRepository,
                 submitsRepository: submitsRepository
             )
             


### PR DESCRIPTION
## What is this PR?
- [x] 플레이어 구현(MusicPanel)
- [x] 플레이어와 아트워크, 프리뷰 연동(더미 url로 테스트 완료)
- [x] 녹음 버튼 수정
- [x] 제출 현황 딱지 수정
- [x] 비주얼라이저 기능 달기
 
## PR Type
- [ ] Bugfix
- [ ] Chore
- [x] New feature (기능을 추가하는 feat)
- [ ] Breaking change (기존의 기능이 동작하지 않을 수 있는 fix/feat)
- [ ] Documentation Update

## ScreenShot(if available)
|기능|스크린샷|
|:--:|:--:|
|아트워크 없을 때|<img src = "https://github.com/user-attachments/assets/dd5b93dd-471b-4cde-8766-3920cf0f103c" width ="250">|
|아트워크 있을 때|<img src = "https://github.com/user-attachments/assets/d027944d-32ad-48fc-93d8-5f65422876bd" width ="250">|



## Further comments
- 너무 졸려서 ... 아래 두개는 못햇습니다ㅠ
- 허밍, 리허밍 뷰에서 사용할 플레이어(MusicPanel, ASMusicPlayer)를 구현했습니다. 이 과정에서 고민이 좀 있었는데요,
  현재 HummingViewController에서 내가 고른 음악(Answer 배열에서 내 id와 동일한 것)을 받아오고, 받아온 이후에 music에 저장하고 musicPreview`(노래 프리뷰(허밍 status)/허밍(리허밍 status) 파일, 개명 예정)`를 받아서 뷰모델에 저장해 둡니다. 동시에 ASMusicPlayer는 아트워크를 다운로드받습니다.

  ASMusicPlayer에서 아트워크 이미지를 다운로드 받은 이유는 viewmodel에서 딱히 사용하지 않아서이며, 비즈니스 로직을 포함하지는 않는다고 생각했기 때문입니다. 그러나 똑같이 ASMusicPlayer의 플레이 버튼으로 트리거되는 음악 재생은 viewmodel에서 처리하는데 이게 과연 맞는지..? 의구심이 들었어요.

  ASMusicPlayer 독단적으로 행동할 수 있게 얘한테 프리뷰와 아트워크 정보를 모두 주게 되면 음악 플레이를 담당해야 하기에 View라고 볼 수는 없을 것 같고, 모두 viewmodel에서 받아와서 쓰게 하기에는 굳이...? 라는 생각이 들었는데 어떻게 생각하시나요? 혼이 반쯤 나가서 두서없어서 지송합니다..
- Music 구조체에 artwork, preview를 추가했습니다.
- ASMusicKit에서 ASSong을 쓰고 있던데, ASEntity에 있는 구조체를 사용하는 게 나을 것 같아요.

---
2024.11.25 추가
---
## 주요 작업
- 제출 현황 딱지 추가
- 비주얼라이저에 재생 기능 추가
- [8aa40ee](https://github.com/boostcampwm-2024/iOS07-alsongDalsong/pull/95/commits/8aa40ee01c7a3baebec80de9b2cfb822d32aabf6)에서 구현한 MusicPanel 자체가 음악 재생을 담당하도록 변경([17a2a48](https://github.com/boostcampwm-2024/iOS07-alsongDalsong/pull/95/commits/17a2a486ac775300988b3bb4168dc597fdec52a1))
- 비주얼라이저가 녹음을 담당하도록 변경([a953335](https://github.com/boostcampwm-2024/iOS07-alsongDalsong/pull/95/commits/a953335b8657373708fbf3687cd20710295baa03))

## ScreenShot(if available)
|기능|스크린샷|
|:--:|:--:|
|허밍뷰|<img src = "https://github.com/user-attachments/assets/ca046d87-6457-47e4-8790-c6d64f6e6e29" width ="250">|

## Further Comments
- recordPanel(허밍 패널)에 디버깅할 수 없는 오류가 있습니다. 

|오작동|스크린샷|
|:--:|:--:|
|허밍뷰|<img src = "https://github.com/user-attachments/assets/5a119adc-a2e7-415a-af4e-65bf4c76d518" width ="250">|

- 뷰모델의 isPlaying을 옵저빙하면서 상태를 변경하는데, isPlaying은 단 한번만 변경되지만 정지 -> 플레이 변환 시 3번 정도 전환합니다.
- 옵저빙하는 sink 클로저에서 print를 찍어봐도 단 한 번만 변경됩니다.
- 옵저빙하는 방식이 아닌 누르면 바로 변경되는 방식으로는 정상적으로 작동합니다.
- 옵저빙해야 하는 이유: 뷰모델에서 음원 파일을 재생하고 정지하는데, 재생/정지 버튼을 누르면 뷰모델에서 처리해야 합니다. 이때 음원 파일이 없는 경우를 고려해야 하는데, 없는 경우는 버튼 상태를 바꾸지 않아야 합니다. 또한 음원을 모두 재생했을 때 버튼 상태가 바뀌는 방식입니다(재생 -> 정지).