### PR TITLE
feat: 온보딩 UI 수정

### DIFF
--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/ASAlertController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/ASAlertController.swift
@@ -5,7 +5,7 @@ class ASAlertController: UIViewController {
     private var textField = ASTextField()
     private var doneButton = ASButton()
     private var cancelButton = ASButton()
-    //Alert창에 입력한 text
+    // Alert창에 입력한 text
     var text: String {
         textField.text ?? ""
     }
@@ -14,6 +14,7 @@ class ASAlertController: UIViewController {
     private var textFieldPlaceholder: String = ""
     private var doneButtonTitle: String = ""
     private var cancelButtonTitle: String = ""
+    private var isUppercased: Bool = false
     
     var doneButtonCompletion: (() -> Void)?
     var cancelButtonCompletion: (() -> Void)?
@@ -22,6 +23,10 @@ class ASAlertController: UIViewController {
         super.viewDidLoad()
         setupUI(titleText: titleText, textFieldPlaceholder: textFieldPlaceholder, doneButtonTitle: doneButtonTitle, cancelButtonTitle: cancelButtonTitle)
         setupLayout()
+        
+        if isUppercased {
+            textField.delegate = self
+        }
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -33,7 +38,7 @@ class ASAlertController: UIViewController {
     }
     
     private func setupUI(titleText: String, textFieldPlaceholder: String, doneButtonTitle: String, cancelButtonTitle: String) {
-        self.view.backgroundColor = .black.withAlphaComponent(0.3)
+        view.backgroundColor = .black.withAlphaComponent(0.3)
         alertView.setConfiguration(title: titleText, titleAlign: .center, titleSize: 24)
         alertView.transform = CGAffineTransform(scaleX: 1.2, y: 1.2)
         alertView.backgroundColor = .asLightGray
@@ -90,14 +95,32 @@ class ASAlertController: UIViewController {
 }
 
 extension ASAlertController {
-    convenience init(titleText: String, doneButtonTitle: String, cancelButtonTitle: String, textFieldPlaceholder: String) {
+    convenience init(titleText: String, doneButtonTitle: String, cancelButtonTitle: String, textFieldPlaceholder: String, isUppercased: Bool = false) {
         self.init()
         self.titleText = titleText
         self.textFieldPlaceholder = textFieldPlaceholder
         self.doneButtonTitle = doneButtonTitle
         self.cancelButtonTitle = cancelButtonTitle
+        self.isUppercased = isUppercased
         
         self.modalTransitionStyle = .crossDissolve
         self.modalPresentationStyle = .overFullScreen
+    }
+}
+
+extension ASAlertController: UITextFieldDelegate {
+    func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
+        let uppercaseString = string.uppercased()
+        if string == uppercaseString {
+            return true
+        } else {
+            if let text = textField.text,
+               let textRange = Range(range, in: text)
+            {
+                let updatedText = text.replacingCharacters(in: textRange, with: uppercaseString)
+                textField.text = updatedText
+            }
+            return false
+        }
     }
 }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/ASAlertController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/ASAlertController.swift
@@ -15,6 +15,7 @@ class ASAlertController: UIViewController {
     private var doneButtonTitle: String = ""
     private var cancelButtonTitle: String = ""
     private var isUppercased: Bool = false
+    private var textMaxCount: Int = 6
     
     var doneButtonCompletion: (() -> Void)?
     var cancelButtonCompletion: (() -> Void)?
@@ -111,16 +112,19 @@ extension ASAlertController {
 extension ASAlertController: UITextFieldDelegate {
     func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
         let uppercaseString = string.uppercased()
-        if string == uppercaseString {
-            return true
-        } else {
-            if let text = textField.text,
-               let textRange = Range(range, in: text)
-            {
-                let updatedText = text.replacingCharacters(in: textRange, with: uppercaseString)
+        
+        if let text = textField.text,
+           let textRange = Range(range, in: text)
+        {
+            let updatedText = text.replacingCharacters(in: textRange, with: uppercaseString)
+            if updatedText.count <= textMaxCount {
                 textField.text = updatedText
+                return false
+            } else {
+                return false
             }
-            return false
         }
+        
+        return true
     }
 }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/ASAlertController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/ASAlertController.swift
@@ -149,10 +149,8 @@ extension ASAlertController: UITextFieldDelegate {
             let updatedText = text.replacingCharacters(in: textRange, with: uppercaseString)
             if updatedText.count <= textMaxCount {
                 textField.text = updatedText
-                return false
-            } else {
-                return false
             }
+            return false
         }
         
         return true

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/ASAlertController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/ASAlertController.swift
@@ -16,6 +16,7 @@ class ASAlertController: UIViewController {
     private var cancelButtonTitle: String = ""
     private var isUppercased: Bool = false
     private var textMaxCount: Int = 6
+    private var style: ASAlertStyle = .default
     
     var doneButtonCompletion: (() -> Void)?
     var cancelButtonCompletion: (() -> Void)?
@@ -23,8 +24,13 @@ class ASAlertController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         setupUI(titleText: titleText, textFieldPlaceholder: textFieldPlaceholder, doneButtonTitle: doneButtonTitle, cancelButtonTitle: cancelButtonTitle)
-        setupLayout()
         
+        switch style {
+        case .input:
+            setupInputStyleLayout()
+        case .default:
+            setupDefaultStyleLayout()
+        }
         if isUppercased {
             textField.delegate = self
         }
@@ -46,26 +52,49 @@ class ASAlertController: UIViewController {
         alertView.layer.borderWidth = 0
         view.addSubview(alertView)
         
-        textField.setConfiguration(placeholder: textFieldPlaceholder)
-        alertView.addSubview(textField)
-        
         doneButton.setConfiguration(systemImageName: "", title: doneButtonTitle, backgroundColor: .asLightSky, textSize: 24)
-        cancelButton.setConfiguration(systemImageName: "", title: cancelButtonTitle, backgroundColor: .asLightRed, textSize: 24)
+        
         alertView.addSubview(doneButton)
-        alertView.addSubview(cancelButton)
         
         doneButton.addAction(UIAction { [weak self] _ in
             self?.doneButtonCompletion?()
             self?.dismiss(animated: true)
         }, for: .touchUpInside)
         
-        cancelButton.addAction(UIAction { [weak self] _ in
-            self?.cancelButtonCompletion?()
-            self?.dismiss(animated: true)
-        }, for: .touchUpInside)
+        switch style {
+        case .input:
+            textField.setConfiguration(placeholder: textFieldPlaceholder)
+            alertView.addSubview(textField)
+            
+            cancelButton.setConfiguration(systemImageName: "", title: cancelButtonTitle, backgroundColor: .asLightRed, textSize: 24)
+            alertView.addSubview(cancelButton)
+            cancelButton.addAction(UIAction { [weak self] _ in
+                self?.cancelButtonCompletion?()
+                self?.dismiss(animated: true)
+            }, for: .touchUpInside)
+        case .default:
+            break
+        }
     }
-    
-    private func setupLayout() {
+
+    private func setupDefaultStyleLayout() {
+        alertView.translatesAutoresizingMaskIntoConstraints = false
+        doneButton.translatesAutoresizingMaskIntoConstraints = false
+        
+        NSLayoutConstraint.activate([
+            alertView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            alertView.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+            alertView.widthAnchor.constraint(equalToConstant: 345),
+            alertView.heightAnchor.constraint(equalToConstant: 180),
+            
+            doneButton.leadingAnchor.constraint(equalTo: alertView.leadingAnchor, constant: 12),
+            doneButton.trailingAnchor.constraint(equalTo: alertView.trailingAnchor, constant: -12),
+            doneButton.bottomAnchor.constraint(equalTo: alertView.bottomAnchor, constant: -24),
+            doneButton.heightAnchor.constraint(equalToConstant: 40),
+        ])
+    }
+
+    private func setupInputStyleLayout() {
         alertView.translatesAutoresizingMaskIntoConstraints = false
         textField.translatesAutoresizingMaskIntoConstraints = false
         doneButton.translatesAutoresizingMaskIntoConstraints = false
@@ -96,13 +125,14 @@ class ASAlertController: UIViewController {
 }
 
 extension ASAlertController {
-    convenience init(titleText: String, doneButtonTitle: String, cancelButtonTitle: String, textFieldPlaceholder: String, isUppercased: Bool = false) {
+    convenience init(titleText: String, doneButtonTitle: String, cancelButtonTitle: String, textFieldPlaceholder: String, isUppercased: Bool = false, style: ASAlertStyle) {
         self.init()
         self.titleText = titleText
         self.textFieldPlaceholder = textFieldPlaceholder
         self.doneButtonTitle = doneButtonTitle
         self.cancelButtonTitle = cancelButtonTitle
         self.isUppercased = isUppercased
+        self.style = style
         
         self.modalTransitionStyle = .crossDissolve
         self.modalPresentationStyle = .overFullScreen
@@ -127,4 +157,9 @@ extension ASAlertController: UITextFieldDelegate {
         
         return true
     }
+}
+
+enum ASAlertStyle {
+    case input
+    case `default`
 }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/ASButton.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/ASButton.swift
@@ -1,6 +1,6 @@
 import Combine
-import UIKit
 import SwiftUI
+import UIKit
 
 class ASButton: UIButton {
     private var cancellables = Set<AnyCancellable>()
@@ -25,7 +25,6 @@ class ASButton: UIButton {
         textSize: CGFloat = 32
     ) {
         var config = UIButton.Configuration.gray()
-
         config.baseBackgroundColor = backgroundColor
         config.baseForegroundColor = .asBlack
 
@@ -47,8 +46,22 @@ class ASButton: UIButton {
 
         config.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 12, bottom: 0, trailing: 12)
         config.cornerStyle = .medium
-        configuration = config
+
         setShadow()
+        config.background.backgroundColorTransformer = UIConfigurationColorTransformer { color in
+            color.withAlphaComponent(1.0)
+        }
+
+        configurationUpdateHandler = { [weak self] _ in
+            guard let self else { return }
+            if self.isHighlighted {
+                self.transform = CGAffineTransform(scaleX: 0.96, y: 0.96)
+            }
+            else {
+                self.transform = .identity
+            }
+            self.configuration = config
+        }
     }
 
     func bind(
@@ -76,7 +89,5 @@ struct ASButtonWrapper: UIViewRepresentable {
         return view
     }
 
-    func updateUIView(_ uiView: ASButton, context: Context) {
-
-    }
+    func updateUIView(_ uiView: ASButton, context: Context) {}
 }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/ASTextField.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/ASTextField.swift
@@ -1,24 +1,17 @@
-//
-//  ASTextField.swift
-//  alsongDalsong
-//
-//  Created by Minha Lee on 11/14/24.
-//
-
 import UIKit
 
 class ASTextField: UITextField {
     init() {
         super.init(frame: .zero)
     }
-    
+
     func setConfiguration(
         placeholder: String = "텍스트를 입력하세요",
         backgroundColor: UIColor = .asSystem,
         textSize: CGFloat = 32
     ) {
         layer.cornerRadius = 12
-        
+
         attributedPlaceholder = NSAttributedString(string: placeholder, attributes: [.foregroundColor: UIColor.lightGray])
         self.backgroundColor = backgroundColor
         font = UIFont.font(.dohyeon, ofSize: textSize)
@@ -27,9 +20,8 @@ class ASTextField: UITextField {
         leftView = UIView(frame: CGRect(x: 0, y: 0, width: 10, height: 0))
         leftViewMode = .always
     }
-    
+
     required init?(coder: NSCoder) {
         super.init(coder: coder)
     }
-    
 }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Extensions/UIViewController+Keyboard.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Extensions/UIViewController+Keyboard.swift
@@ -11,8 +11,29 @@ extension UIViewController {
             )
         )
     }
-    
+
     @objc func dismissKeyboard() {
+        view.endEditing(true)
+    }
+
+    @objc func keyboardWillShow(_ notification: NSNotification) {
+        if let keyboardFrame: NSValue = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue {
+            let keyboardRectangle = keyboardFrame.cgRectValue
+            let keyboardHeight = keyboardRectangle.height
+
+            UIView.animate(withDuration: 0.3) {
+                self.view.transform = CGAffineTransform(translationX: 0, y: -keyboardHeight)
+            }
+        }
+    }
+
+    @objc func keyboardWillHide(_ notification: NSNotification) {
+        UIView.animate(withDuration: 0.3) {
+            self.view.transform = .identity
+        }
+    }
+
+    @objc func appDidEnterBackground(_ notification: NSNotification) {
         view.endEditing(true)
     }
 }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Onboarding/OnboardingViewController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Onboarding/OnboardingViewController.swift
@@ -214,6 +214,7 @@ final class OnboardingViewController: UIViewController {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] success in
                 if !success {
+                    self?.createRoomButton.isHidden = false
                     let joinFailedAlert = ASAlertController(
                         titleText: "참가에 실패하였습니다.",
                         doneButtonTitle: "확인",

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Onboarding/OnboardingViewController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Onboarding/OnboardingViewController.swift
@@ -43,6 +43,7 @@ final class OnboardingViewController: UIViewController {
         super.viewWillAppear(animated)
         NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillShow(_:)), name: UIResponder.keyboardWillShowNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillHide(_:)), name: UIResponder.keyboardWillHideNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(appDidEnterBackground(_:)), name: UIApplication.didEnterBackgroundNotification, object: nil)
     }
 
     override func viewWillDisappear(_ animated: Bool) {
@@ -207,25 +208,6 @@ final class OnboardingViewController: UIViewController {
                 self?.joinRoomButton.isEnabled = enabled
             }
             .store(in: &cancleables)
-    }
-}
-
-extension OnboardingViewController {
-    @objc func keyboardWillShow(_ notification: NSNotification) {
-        if let keyboardFrame: NSValue = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue {
-            let keyboardRectangle = keyboardFrame.cgRectValue
-            let keyboardHeight = keyboardRectangle.height
-            
-            UIView.animate(withDuration: 0.3) {
-                self.view.transform = CGAffineTransform(translationX: 0, y: -keyboardHeight)
-            }
-        }
-    }
-
-    @objc func keyboardWillHide(_ notification: NSNotification) {
-        UIView.animate(withDuration: 0.3) {
-            self.view.transform = .identity
-        }
     }
 }
 

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Onboarding/OnboardingViewController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Onboarding/OnboardingViewController.swift
@@ -124,8 +124,9 @@ final class OnboardingViewController: UIViewController {
                         doneButtonTitle: Constants.doneAlertButtonTitle,
                         cancelButtonTitle: Constants.cancelAlertButtonTitle,
                         textFieldPlaceholder: Constants.roomNumberPlaceholder,
-                        isUppercased: true)
-                        
+                        isUppercased: true,
+                        style: .input)
+                    
                     joinAlert.doneButtonCompletion = { [weak self] in
                         if let nickname = self?.nickNameTextField.text, nickname.count > 0 {
                             self?.viewmodel?.setNickname(with: nickname)
@@ -206,6 +207,22 @@ final class OnboardingViewController: UIViewController {
             .sink { [weak self] enabled in
                 self?.createRoomButton.isEnabled = enabled
                 self?.joinRoomButton.isEnabled = enabled
+            }
+            .store(in: &cancleables)
+        
+        viewmodel?.$joinResponse
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] success in
+                if !success {
+                    let joinFailedAlert = ASAlertController(
+                        titleText: "참가에 실패하였습니다.",
+                        doneButtonTitle: "확인",
+                        cancelButtonTitle: Constants.cancelAlertButtonTitle,
+                        textFieldPlaceholder: Constants.roomNumberPlaceholder,
+                        isUppercased: true,
+                        style: .default)
+                    self?.present(joinFailedAlert, animated: true, completion: nil)
+                }
             }
             .store(in: &cancleables)
     }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Onboarding/OnboardingViewController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Onboarding/OnboardingViewController.swift
@@ -14,7 +14,7 @@ final class OnboardingViewController: UIViewController {
     private var avatarRefreshButton = ASRefreshButton(size: 28)
     private var viewmodel: OnboardingViewModel?
     private var inviteCode: String
-    
+    private var nickNameTextFieldMaxCount = 12
     private var cancleables = Set<AnyCancellable>()
     
     init(viewmodel: OnboardingViewModel, inviteCode: String) {
@@ -60,6 +60,8 @@ final class OnboardingViewController: UIViewController {
         if !inviteCode.isEmpty {
             createRoomButton.isHidden = true
         }
+        
+        nickNameTextField.delegate = self
     }
     
     private func setupLayout() {
@@ -224,6 +226,23 @@ extension OnboardingViewController {
         UIView.animate(withDuration: 0.3) {
             self.view.transform = .identity
         }
+    }
+}
+
+extension OnboardingViewController: UITextFieldDelegate {
+    func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
+        guard let currentText = textField.text,
+              let stringRange = Range(range, in: currentText)
+        else {
+            return false
+        }
+        let updatedText = currentText.replacingCharacters(in: stringRange, with: string)
+        guard updatedText.count <= nickNameTextFieldMaxCount else {
+            return false
+        }
+        let allowedCharacters = CharacterSet.alphanumerics.union(.whitespaces)
+        let characterSet = CharacterSet(charactersIn: string)
+        return allowedCharacters.isSuperset(of: characterSet)
     }
 }
 

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Onboarding/OnboardingViewController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Onboarding/OnboardingViewController.swift
@@ -120,8 +120,9 @@ final class OnboardingViewController: UIViewController {
                         titleText: Constants.joinAlertTitle,
                         doneButtonTitle: Constants.doneAlertButtonTitle,
                         cancelButtonTitle: Constants.cancelAlertButtonTitle,
-                        textFieldPlaceholder: Constants.roomNumberPlaceholder)
-                    
+                        textFieldPlaceholder: Constants.roomNumberPlaceholder,
+                        isUppercased: true)
+                        
                     joinAlert.doneButtonCompletion = { [weak self] in
                         if let nickname = self?.nickNameTextField.text, nickname.count > 0 {
                             self?.viewmodel?.setNickname(with: nickname)

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Onboarding/OnboardingViewController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Onboarding/OnboardingViewController.swift
@@ -39,6 +39,17 @@ final class OnboardingViewController: UIViewController {
         bind()
     }
     
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillShow(_:)), name: UIResponder.keyboardWillShowNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillHide(_:)), name: UIResponder.keyboardWillHideNotification, object: nil)
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        NotificationCenter.default.removeObserver(self)
+    }
+    
     private func setupUI() {
         view.backgroundColor = .asLightGray
         for item in [createRoomButton, joinRoomButton, logoImageView, avatarView, nickNamePanel, nickNameTextField, avatarRefreshButton] {
@@ -181,8 +192,7 @@ final class OnboardingViewController: UIViewController {
                     playersRepository: playersRepository,
                     roomInfoRepository: roomInfoRepository,
                     roomActionRepository: roomActionRepository,
-                    avatarRepository: avatarRepository
-                )
+                    avatarRepository: avatarRepository)
                 let lobbyViewController = LobbyViewController(lobbyViewModel: lobbyViewModel)
                 self?.navigationController?.pushViewController(lobbyViewController, animated: false)
             }
@@ -194,6 +204,25 @@ final class OnboardingViewController: UIViewController {
                 self?.joinRoomButton.isEnabled = enabled
             }
             .store(in: &cancleables)
+    }
+}
+
+extension OnboardingViewController {
+    @objc func keyboardWillShow(_ notification: NSNotification) {
+        if let keyboardFrame: NSValue = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue {
+            let keyboardRectangle = keyboardFrame.cgRectValue
+            let keyboardHeight = keyboardRectangle.height
+            
+            UIView.animate(withDuration: 0.3) {
+                self.view.transform = CGAffineTransform(translationX: 0, y: -keyboardHeight)
+            }
+        }
+    }
+
+    @objc func keyboardWillHide(_ notification: NSNotification) {
+        UIView.animate(withDuration: 0.3) {
+            self.view.transform = .identity
+        }
     }
 }
 

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Onboarding/OnboardingViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Onboarding/OnboardingViewModel.swift
@@ -15,6 +15,7 @@ final class OnboardingViewModel {
     @Published var avatarData: Data?
     @Published var roomNumber: String = ""
     @Published var buttonEnabled: Bool = true
+    @Published var joinResponse: Bool = true
     
     init(avatarRepository: AvatarRepositoryProtocol,
          roomActionRepository: RoomActionRepositoryProtocol)
@@ -80,6 +81,7 @@ final class OnboardingViewModel {
                 case .failure(let error):
                     print(error.localizedDescription)
                     self?.buttonEnabled = true
+                    self?.joinResponse = false
                 }
             } receiveValue: { [weak self] isSuccess in
                 if isSuccess {

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Onboarding/OnboardingViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Onboarding/OnboardingViewModel.swift
@@ -70,7 +70,7 @@ final class OnboardingViewModel {
     
     func joinRoom(roomNumber id: String) {
         guard let selectedAvatar else { return }
-        self.buttonEnabled = false
+        buttonEnabled = false
         roomActionRepository.joinRoom(nickname: nickname, avatar: selectedAvatar, roomNumber: id)
             .receive(on: DispatchQueue.main)
             .sink { [weak self] completion in
@@ -92,7 +92,7 @@ final class OnboardingViewModel {
     
     func createRoom() {
         guard let selectedAvatar else { return }
-        self.buttonEnabled = false
+        buttonEnabled = false
         roomActionRepository.createRoom(nickname: nickname, avatar: selectedAvatar)
             .receive(on: DispatchQueue.main)
             .sink { [weak self] completion in


### PR DESCRIPTION
## What is this PR?
- 닉네임 입력 필드가 키보드에 안 가리도록 수정
  - 이후 키보드가 뜬 상태에서 백그라운드로 진입하면 키보드가 사라질때 화면이 덩달아 내려가버리는 버그 찾았는데 이것도 수정함.
- 버튼 focus 상태 투명해지는 거 변경
  - 투명해지는 것 없앴고 누를 때 사이즈 살짝 변경되게 됨
- 닉네임 제한
  - 숫자, 공백은 허용하도록 하였고 닉네임 뿐만 아니라 방코드 입력하는 TextField도 6자로 제한함
- 방 번호입력시 대문자 자동(실시간) 변환
- 방참가시 실패시 Alert 띄워줌
  - 이에 따라 alert style을 추가해줬음 (기존에는 텍스트 필드를 갖고있는 것 밖에 없었음)
- 딥링크 참가시 유효한 방이 아닐경우 방생성 버튼 다시 보여주기

## PR Type
- [ ] Bugfix
- [ ] Chore
- [x] New feature (기능을 추가하는 feat)
- [ ] Breaking change (기존의 기능이 동작하지 않을 수 있는 fix/feat)
- [ ] Documentation Update
