### PR TITLE
feat: 제출 시 로딩UI 띄우기, 제출 버튼 비활성화 

### DIFF
--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/ASAlertController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/ASAlertController.swift
@@ -349,10 +349,12 @@ enum ASAlertText {
 
     enum ProgressText: CustomStringConvertible {
         case joinRoom
+        case submitMusic
 
         var description: String {
             switch self {
                 case .joinRoom: "방 정보를 가져오는 중..."
+                case .submitMusic: "음악 전송 중..."
             }
         }
     }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/ASButton.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/ASButton.swift
@@ -61,7 +61,7 @@ final class ASButton: UIButton {
                 self.transform = .identity
             }
         }
-        self.configuration = config
+        configuration = config
     }
 
     private func disable(_ color: UIColor = .systemGray2) {
@@ -88,11 +88,12 @@ final class ASButton: UIButton {
             case let .idle(string, color): setConfiguration(title: string, backgroundColor: color)
             case .recording: setConfiguration(title: "녹음중..", backgroundColor: .asLightRed)
             case .reRecord: setConfiguration(systemImageName: "arrow.clockwise", title: "재녹음", backgroundColor: .asOrange)
+            case .complete: setConfiguration(title: "완료")
         }
     }
 
     enum ASButtonType {
-        case disabled, idle(String, UIColor?), recording, reRecord
+        case disabled, idle(String, UIColor?), recording, reRecord, complete
     }
 }
 

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Game/GameNavigationController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Game/GameNavigationController.swift
@@ -108,7 +108,7 @@ final class GameNavigationController {
             answersRepository: answersRepository,
             recordsRepository: recordsRepository
         )
-        let vc = HummingViewController(vm: vm)
+        let vc = HummingViewController(viewModel: vm)
         navigationController.pushViewController(vc, animated: true)
     }
     

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Game/GameNavigationController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Game/GameNavigationController.swift
@@ -122,7 +122,7 @@ final class GameNavigationController {
             playersRepository: playersRepository,
             recordsRepository: recordsRepository
         )
-        let vc = RehummingViewController(vm: vm)
+        let vc = RehummingViewController(viewModel: vm)
         navigationController.pushViewController(vc, animated: true)
     }
     

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Humming/HummingView.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Humming/HummingView.swift
@@ -56,12 +56,12 @@ final class HummingViewController: UIViewController {
                 let gameStatusRepository = DIContainer.shared.resolve(GameStatusRepositoryProtocol.self)
                 let playersRepository = DIContainer.shared.resolve(PlayersRepositoryProtocol.self)
                 let recordsRepository = DIContainer.shared.resolve(RecordsRepositoryProtocol.self)
-                let vm = RehummingViewModel(
+                let viewModel = RehummingViewModel(
                     gameStatusRepository: gameStatusRepository,
                     playersRepository: playersRepository,
                     recordsRepository: recordsRepository
                 )
-                let vc = RehummingViewController(viewModel: vm)
+                let vc = RehummingViewController(viewModel: viewModel)
                 self?.navigationController?.pushViewController(vc, animated: true)
             }, for: .touchUpInside
         )

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Humming/HummingView.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Humming/HummingView.swift
@@ -61,7 +61,7 @@ final class HummingViewController: UIViewController {
                     playersRepository: playersRepository,
                     recordsRepository: recordsRepository
                 )
-                let vc = RehummingViewController(vm: vm)
+                let vc = RehummingViewController(viewModel: vm)
                 self?.navigationController?.pushViewController(vc, animated: true)
             }, for: .touchUpInside
         )

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Humming/HummingViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Humming/HummingViewModel.swift
@@ -33,19 +33,17 @@ final class HummingViewModel: @unchecked Sendable {
         bindAnswer()
     }
 
-    func submitHumming() {
+    func submitHumming() async {
         guard let recordedData else { return }
-        Task {
-            do {
-                let result = try await recordsRepository.uploadRecording(recordedData)
-                if result {
-                    // 전송됨
-                } else {
-                    // 전송 안됨, 오류 alert
-                }
-            } catch {
+        do {
+            let result = try await recordsRepository.uploadRecording(recordedData)
+            if result {
+                // 전송됨
+            } else {
                 // 전송 안됨, 오류 alert
             }
+        } catch {
+            // 전송 안됨, 오류 alert
         }
     }
 

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Rehumming/RehummingView.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Rehumming/RehummingView.swift
@@ -56,12 +56,12 @@ final class RehummingViewController: UIViewController {
                 let gameStatusRepository = DIContainer.shared.resolve(GameStatusRepositoryProtocol.self)
                 let playersRepository = DIContainer.shared.resolve(PlayersRepositoryProtocol.self)
                 let recordsRepository = DIContainer.shared.resolve(RecordsRepositoryProtocol.self)
-                let vm = RehummingViewModel(
+                let viewModel = RehummingViewModel(
                     gameStatusRepository: gameStatusRepository,
                     playersRepository: playersRepository,
                     recordsRepository: recordsRepository
                 )
-                let vc = RehummingViewController(viewModel: vm)
+                let vc = RehummingViewController(viewModel: viewModel)
                 self?.navigationController?.pushViewController(vc, animated: true)
             }, for: .touchUpInside
         )

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Rehumming/RehummingView.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Rehumming/RehummingView.swift
@@ -11,10 +11,10 @@ final class RehummingViewController: UIViewController {
     private var submitButton = ASButton()
     private var submissionStatus = SubmissionStatusView()
     private var buttonStack = UIStackView()
-    private let vm: RehummingViewModel
+    private let viewModel: RehummingViewModel
 
-    init(vm: RehummingViewModel) {
-        self.vm = vm
+    init(viewModel: RehummingViewModel) {
+        self.viewModel = viewModel
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -30,15 +30,15 @@ final class RehummingViewController: UIViewController {
     }
 
     private func bindToComponents() {
-        submissionStatus.bind(to: vm.$submissionStatus)
-        progressBar.bind(to: vm.$dueTime)
-        musicPanel.bind(to: vm.$music)
-        hummingPanel.bind(to: vm.$isRecording)
+        submissionStatus.bind(to: viewModel.$submissionStatus)
+        progressBar.bind(to: viewModel.$dueTime)
+        musicPanel.bind(to: viewModel.$music)
+        hummingPanel.bind(to: viewModel.$isRecording)
         hummingPanel.onRecordingFinished = { [weak self] recordedData in
             self?.recordButton.updateButton(.reRecord)
-            self?.vm.updateRecordedData(with: recordedData)
+            self?.viewModel.updateRecordedData(with: recordedData)
         }
-        submitButton.bind(to: vm.$recordedData)
+        submitButton.bind(to: viewModel.$recordedData)
     }
 
     private func setupUI() {
@@ -46,13 +46,13 @@ final class RehummingViewController: UIViewController {
         recordButton.setConfiguration(title: "녹음하기", backgroundColor: .systemRed)
         recordButton.addAction(UIAction { [weak self] _ in
             self?.recordButton.updateButton(.recording)
-            self?.vm.startRecording()
+            self?.viewModel.startRecording()
         },
         for: .touchUpInside)
         submitButton.setConfiguration(title: "녹음 완료", backgroundColor: .asLightGray)
         submitButton.addAction(
             UIAction { [weak self] _ in
-                self?.vm.submitHumming()
+                self?.showSubmitLoading()
                 let gameStatusRepository = DIContainer.shared.resolve(GameStatusRepositoryProtocol.self)
                 let playersRepository = DIContainer.shared.resolve(PlayersRepositoryProtocol.self)
                 let recordsRepository = DIContainer.shared.resolve(RecordsRepositoryProtocol.self)
@@ -61,7 +61,7 @@ final class RehummingViewController: UIViewController {
                     playersRepository: playersRepository,
                     recordsRepository: recordsRepository
                 )
-                let vc = RehummingViewController(vm: vm)
+                let vc = RehummingViewController(viewModel: vm)
                 self?.navigationController?.pushViewController(vc, animated: true)
             }, for: .touchUpInside
         )
@@ -77,11 +77,18 @@ final class RehummingViewController: UIViewController {
         view.addSubview(hummingPanel)
         view.addSubview(buttonStack)
         view.addSubview(submissionStatus)
-        submitButton.addAction(
-            UIAction { [weak self] _ in
-                
-        }, for: .touchUpInside)
         submitButton.isEnabled = false
+
+        progressBar.setCompletionHandler { [weak self] in
+            self?.showSubmitLoading()
+        }
+    }
+
+    func showSubmitLoading() {
+        let alert = ASAlertController(progressText: .submitMusic) { [weak self] in
+            await self?.viewModel.submitHumming()
+        }
+        presentLoadingView(alert)
     }
 
     private func setupLayout() {

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Rehumming/RehummingViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Rehumming/RehummingViewModel.swift
@@ -29,19 +29,17 @@ final class RehummingViewModel: @unchecked Sendable {
         bindSubmitStatus()
     }
 
-    func submitHumming() {
+    func submitHumming() async {
         guard let recordedData else { return }
-        Task {
-            do {
-                let result = try await recordsRepository.uploadRecording(recordedData)
-                if result {
-                    // 전송됨
-                } else {
-                    // 전송 안됨, 오류 alert
-                }
-            } catch {
+        do {
+            let result = try await recordsRepository.uploadRecording(recordedData)
+            if result {
+                // 전송됨
+            } else {
                 // 전송 안됨, 오류 alert
             }
+        } catch {
+            // 전송 안됨, 오류 alert
         }
     }
 
@@ -61,7 +59,7 @@ final class RehummingViewModel: @unchecked Sendable {
         recordedData = data
         isRecording = false
     }
-    
+
     private func bindRecord(on recordOrder: UInt8) {
         recordsRepository.getHumming(on: recordOrder)
             .sink { [weak self] record in

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SelectMusic/SelectMusicViewController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SelectMusic/SelectMusicViewController.swift
@@ -8,10 +8,10 @@ class SelectMusicViewController: UIViewController {
     private var selectMusicView: UIHostingController<SelectMusicView>?
     private let selectCompleteButton = ASButton()
     
-    private let selectMusicViewModel: SelectMusicViewModel
+    private let viewModel: SelectMusicViewModel
     
     init(selectMusicViewModel: SelectMusicViewModel) {
-        self.selectMusicViewModel = selectMusicViewModel
+        self.viewModel = selectMusicViewModel
         super.init(nibName: nil, bundle: nil)
     }
     
@@ -29,8 +29,8 @@ class SelectMusicViewController: UIViewController {
     }
     
     private func bindToComponents() {
-        progressBar.bind(to: selectMusicViewModel.$dueTime)
-        selectCompleteButton.bind(to: selectMusicViewModel.$musicData)
+        progressBar.bind(to: viewModel.$dueTime)
+        selectCompleteButton.bind(to: viewModel.$musicData)
     }
     
     func setupUI() {
@@ -40,7 +40,7 @@ class SelectMusicViewController: UIViewController {
     }
     
     func setupLayout() {
-        let musicView = SelectMusicView(viewModel: selectMusicViewModel)
+        let musicView = SelectMusicView(viewModel: viewModel)
         selectMusicView = UIHostingController(rootView: musicView)
         guard let selectMusicView else { return }
         
@@ -76,13 +76,13 @@ class SelectMusicViewController: UIViewController {
         selectCompleteButton.addAction(UIAction { [weak self] _ in
             self?.selectCompleteButton.updateButton(.complete)
             self?.selectCompleteButton.updateButton(.disabled)
-            self?.selectMusicViewModel.submitMusic()
-            self?.selectMusicViewModel.stopMusic()
+            self?.viewModel.submitMusic()
+            self?.viewModel.stopMusic()
             self?.progressBar.cancelCompletion()
         }, for: .touchUpInside)
         
         progressBar.setCompletionHandler { [weak self] in
-            self?.selectMusicViewModel.submitMusic()
+            self?.viewModel.submitMusic()
         }
     }
 }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SelectMusic/SelectMusicViewController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SelectMusic/SelectMusicViewController.swift
@@ -28,6 +28,13 @@ class SelectMusicViewController: UIViewController {
         bindToComponents()
     }
     
+    func showSubmitLoading() {
+        let alert = ASAlertController(progressText: .submitMusic) { [weak self] in
+            await self?.viewModel.submitMusic()
+        }
+        presentLoadingView(alert)
+    }
+    
     private func bindToComponents() {
         progressBar.bind(to: viewModel.$dueTime)
         selectCompleteButton.bind(to: viewModel.$musicData)
@@ -76,13 +83,13 @@ class SelectMusicViewController: UIViewController {
         selectCompleteButton.addAction(UIAction { [weak self] _ in
             self?.selectCompleteButton.updateButton(.complete)
             self?.selectCompleteButton.updateButton(.disabled)
-            self?.viewModel.submitMusic()
+            self?.showSubmitLoading()
             self?.viewModel.stopMusic()
             self?.progressBar.cancelCompletion()
         }, for: .touchUpInside)
         
         progressBar.setCompletionHandler { [weak self] in
-            self?.viewModel.submitMusic()
+            self?.showSubmitLoading()
         }
     }
 }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SelectMusic/SelectMusicViewController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SelectMusic/SelectMusicViewController.swift
@@ -74,6 +74,8 @@ class SelectMusicViewController: UIViewController {
     
     func setAction() {
         selectCompleteButton.addAction(UIAction { [weak self] _ in
+            self?.selectCompleteButton.updateButton(.complete)
+            self?.selectCompleteButton.updateButton(.disabled)
             self?.selectMusicViewModel.submitMusic()
             self?.selectMusicViewModel.stopMusic()
             self?.progressBar.cancelCompletion()

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SelectMusic/SelectMusicViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SelectMusic/SelectMusicViewModel.swift
@@ -5,7 +5,7 @@ import Combine
 import Foundation
 import MusicKit
 
-final class SelectMusicViewModel: ObservableObject {
+final class SelectMusicViewModel: ObservableObject, @unchecked Sendable {
     @Published public private(set) var answers: [Answer] = []
     @Published public private(set) var searchList: [ASSong] = []
     @Published public private(set) var dueTime: Date?
@@ -21,12 +21,13 @@ final class SelectMusicViewModel: ObservableObject {
             isPlaying = true
         }
     }
+
     @Published public var isPlaying: Bool = false {
         didSet {
             isPlaying ? playingMusic() : stopMusic()
         }
     }
-
+    
     private let musicRepository: MusicRepositoryProtocol
     private let answerRepository: AnswersRepositoryProtocol
     private let gameStatusRepository: GameStatusRepositoryProtocol
@@ -102,8 +103,7 @@ final class SelectMusicViewModel: ObservableObject {
         downloadMusic(url: selectedSong.previewURL)
     }
     
-    @MainActor
-    func submitMusic() {
+    func submitMusic() async {
         let answer = ASEntity.Music(
             title: selectedSong.title,
             artist: selectedSong.artistName,
@@ -114,12 +114,11 @@ final class SelectMusicViewModel: ObservableObject {
             previewUrl: selectedSong.previewURL,
             artworkBackgroundColor: selectedSong.artwork?.backgroundColor?.toHex()
         )
-        Task {
-            do {
-                let response = try await answerRepository.submitMusic(answer: answer)
-            } catch {
-                print(error.localizedDescription)
-            }
+
+        do {
+            let response = try await answerRepository.submitMusic(answer: answer)
+        } catch {
+            print(error.localizedDescription)
         }
     }
  

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SubmitAnswer/SubmitAnswerViewController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SubmitAnswer/SubmitAnswerViewController.swift
@@ -56,12 +56,12 @@ final class SubmitAnswerViewController: UIViewController {
                 let gameStatusRepository = DIContainer.shared.resolve(GameStatusRepositoryProtocol.self)
                 let playersRepository = DIContainer.shared.resolve(PlayersRepositoryProtocol.self)
                 let recordsRepository = DIContainer.shared.resolve(RecordsRepositoryProtocol.self)
-                let vm = RehummingViewModel(
+                let viewModel = RehummingViewModel(
                     gameStatusRepository: gameStatusRepository,
                     playersRepository: playersRepository,
                     recordsRepository: recordsRepository
                 )
-                let vc = RehummingViewController(viewModel: vm)
+                let vc = RehummingViewController(viewModel: viewModel)
                 self?.navigationController?.pushViewController(vc, animated: true)
             }, for: .touchUpInside
         )

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SubmitAnswer/SubmitAnswerViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SubmitAnswer/SubmitAnswerViewModel.swift
@@ -5,7 +5,7 @@ import Combine
 import Foundation
 import MusicKit
 
-final class SubmitAnswerViewModel: ObservableObject {
+final class SubmitAnswerViewModel: ObservableObject, @unchecked Sendable {
     private var cancellable = Set<AnyCancellable>()
     private let musicRepository: MusicRepositoryProtocol
     private let gameStatusRepository: GameStatusRepositoryProtocol
@@ -103,16 +103,19 @@ final class SubmitAnswerViewModel: ObservableObject {
         downloadMusic(url: selectedSong.previewURL)
     }
 
-    @MainActor
-    func submitAnswer() {
+    func submitAnswer() async {
         guard let artworkBackgroundColor = selectedSong.artwork?.backgroundColor?.toHex() else { return }
-        let answer = ASEntity.Music(title: selectedSong.title, artist: selectedSong.artistName, artworkUrl: selectedSong.artwork?.url(width: 300, height: 300), previewUrl: selectedSong.previewURL, artworkBackgroundColor: artworkBackgroundColor)
-        Task {
-            do {
-                let response = try await submitsRepository.submitAnswer(answer: answer)
-            } catch {
-                print(error.localizedDescription)
-            }
+        let answer = ASEntity.Music(
+            title: selectedSong.title,
+            artist: selectedSong.artistName,
+            artworkUrl: selectedSong.artwork?.url(width: 300, height: 300),
+            previewUrl: selectedSong.previewURL,
+            artworkBackgroundColor: artworkBackgroundColor
+        )
+        do {
+            let response = try await submitsRepository.submitAnswer(answer: answer)
+        } catch {
+            print(error.localizedDescription)
         }
     }
 


### PR DESCRIPTION
## What is this PR?
- 제출 버튼 터치시 비활성화 및 완료 상태로 변경
- 음악선택, 허밍, 리허밍, 결과제출 뷰에서 제출시 프로그레스바 뜬 뒤에 다 제출할 때까지 대기하도록 수정
## PR Type
- [ ] Bugfix
- [ ] Chore
- [x] New feature (기능을 추가하는 feat)
- [ ] Breaking change (기존의 기능이 동작하지 않을 수 있는 fix/feat)
- [ ] Documentation Update
