### PR TITLE
feat: Status 에따른 화면 전환 로직, 에러 처리 부분 완성

### DIFF
--- a/alsongDalsong/ASEntity/ASEntity/GameState.swift
+++ b/alsongDalsong/ASEntity/ASEntity/GameState.swift
@@ -3,17 +3,19 @@ public struct GameState {
     public let recordOrder: UInt8?
     public let status: Status?
     public let round: UInt8?
-
+    public let players: [Player]
     public init(
         mode: Mode?,
         recordOrder: UInt8?,
         status: Status?,
-        round: UInt8?
+        round: UInt8?,
+        players: [Player]
     ) {
         self.mode = mode
         self.recordOrder = recordOrder
         self.status = status
         self.round = round
+        self.players = players
     }
 
     public func resolveViewType() -> GameViewType? {
@@ -38,12 +40,19 @@ public struct GameState {
         switch status {
         case .humming:
             if round == 0, recordOrder == 0 {
-                return .selectMusic
+                return .submitMusic
             } else if round == 1, recordOrder == 0 {
                 return .humming
             }
         case .rehumming:
-            if round == 1, recordOrder >= 1 {
+            if players.count <= 2, round == 1, recordOrder == 1 {
+                return .submitAnswer
+            }
+            
+            if round == 1, recordOrder == players.count {
+                return .submitAnswer
+            }
+            else if round == 1, recordOrder >= 1 {
                 return .rehumming
             }
         case .result:
@@ -55,27 +64,28 @@ public struct GameState {
     }
 
     private func resolveHarmonyViewType(status: Status) -> GameViewType {
-        return .selectMusic
+        return .submitMusic
     }
 
     private func resolveSyncViewType(status: Status) -> GameViewType {
-        return .selectMusic
+        return .submitMusic
     }
 
     private func resolveInstantViewType(status: Status) -> GameViewType {
-        return .selectMusic
+        return .submitMusic
     }
 
     private func resolveTTSViewType(status: Status) -> GameViewType {
-        return .selectMusic
+        return .submitMusic
     }
 }
 
 
 public enum GameViewType {
-    case selectMusic
+    case submitMusic
     case humming
     case rehumming
+    case submitAnswer
     case result
     case lobby
 }

--- a/alsongDalsong/ASEntity/ASEntity/GameState.swift
+++ b/alsongDalsong/ASEntity/ASEntity/GameState.swift
@@ -16,7 +16,7 @@ public struct GameState {
         self.round = round
     }
 
-    public func resolveViewType() -> GameViewType {
+    public func resolveViewType() -> GameViewType? {
         guard let mode, let status, let recordOrder, let round else {
             return .lobby
         }
@@ -34,7 +34,7 @@ public struct GameState {
         }
     }
 
-    private func resolveHummingViewType(status: Status, recordOrder: UInt8, round: UInt8) -> GameViewType {
+    private func resolveHummingViewType(status: Status, recordOrder: UInt8, round: UInt8) -> GameViewType? {
         switch status {
         case .humming:
             if round == 0, recordOrder == 0 {
@@ -51,7 +51,7 @@ public struct GameState {
         default:
             return .lobby
         }
-        return .lobby
+        return nil
     }
 
     private func resolveHarmonyViewType(status: Status) -> GameViewType {

--- a/alsongDalsong/ASEntity/ASEntity/Music.swift
+++ b/alsongDalsong/ASEntity/ASEntity/Music.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct Music: Codable, Equatable, Identifiable {
+public struct Music: Codable, Equatable, Identifiable, Sendable {
     public var id: String?
     public var title: String?
     public var artist: String?

--- a/alsongDalsong/ASEntity/ASEntity/Music.swift
+++ b/alsongDalsong/ASEntity/ASEntity/Music.swift
@@ -1,7 +1,7 @@
 import Foundation
 
-public struct Music: Codable, Equatable {
-    public var id: UUID?
+public struct Music: Codable, Equatable, Identifiable {
+    public var id: String?
     public var title: String?
     public var artist: String?
     public var artworkUrl: URL?
@@ -16,7 +16,8 @@ public struct Music: Codable, Equatable {
         self.artist = artist
     }
   
-    public init(title: String?, artist: String?, artworkUrl: URL?, previewUrl: URL?, artworkBackgroundColor: String?) {
+    public init(id: String, title: String?, artist: String?, artworkUrl: URL?, previewUrl: URL?, artworkBackgroundColor: String?) {
+        self.id = id
         self.title = title
         self.artist = artist
         self.artworkUrl = artworkUrl

--- a/alsongDalsong/ASMusicKit/ASMusicKit/ASMusicAPI.swift
+++ b/alsongDalsong/ASMusicKit/ASMusicKit/ASMusicAPI.swift
@@ -41,7 +41,13 @@ public struct ASMusicAPI {
 }
 
 public struct ASSong: Equatable, Identifiable {
-    public init(id: String? = nil, title: String, artistName: String, artwork: Artwork?, previewURL: URL?) {
+    public init(
+        id: String? = nil,
+        title: String = "선택된 곡 없음",
+        artistName: String = "아티스트",
+        artwork: Artwork? = nil,
+        previewURL: URL? = nil
+    ) {
         self.id = id
         self.title = title
         self.artistName = artistName

--- a/alsongDalsong/ASMusicKit/ASMusicKit/ASMusicAPI.swift
+++ b/alsongDalsong/ASMusicKit/ASMusicKit/ASMusicAPI.swift
@@ -47,7 +47,7 @@ public enum ASMusicError: Error, LocalizedError {
     public var errorDescription: String? {
         switch self {
             case .notAuthorized:
-                "에플 뮤직에 접근하는 권한이 없습니다."
+                "애플 뮤직에 접근하는 권한이 없습니다."
             case .searchError:
                 "노래 검색 중 오류가 발생했습니다."
         }

--- a/alsongDalsong/ASMusicKit/ASMusicKit/ASMusicAPI.swift
+++ b/alsongDalsong/ASMusicKit/ASMusicKit/ASMusicAPI.swift
@@ -4,11 +4,11 @@ import MusicKit
 
 public struct ASMusicAPI {
     public init() {}
-    /// MusicKit을 통해 AppleMusic
+    /// MusicKit을 통해 Apple Music의 노래를 검색합니다.
     /// - Parameters:
     ///   - text: 검색 요청을 보낼 검색어
     ///   - maxCount: 검색해서 찾아올 음악의 갯수 기본값 설정은 25
-    /// - Returns: ASSong의 배열
+    /// - Returns: Music의 배열
     @MainActor
     public func search(for text: String, _ maxCount: Int = 25, _ offset: Int = 1) async throws -> [Music] {
         let status = await MusicAuthorization.request()

--- a/alsongDalsong/ASMusicKit/ASMusicKit/ASMusicAPI.swift
+++ b/alsongDalsong/ASMusicKit/ASMusicKit/ASMusicAPI.swift
@@ -10,7 +10,7 @@ public struct ASMusicAPI {
     ///   - maxCount: 검색해서 찾아올 음악의 갯수 기본값 설정은 25
     /// - Returns: ASSong의 배열
     @MainActor
-    public func search(for text: String, _ maxCount: Int = 25, _ offset: Int = 1) async -> [Music] {
+    public func search(for text: String, _ maxCount: Int = 25, _ offset: Int = 1) async throws -> [Music] {
         let status = await MusicAuthorization.request()
         switch status {
             case .authorized:
@@ -32,11 +32,24 @@ public struct ASMusicAPI {
                     }
                     return music
                 } catch {
-                    return []
+                    throw ASMusicError.searchError
                 }
             default:
-                print("Not authorized to access Apple Music")
-                return []
+                throw ASMusicError.notAuthorized
+        }
+    }
+}
+
+public enum ASMusicError: Error, LocalizedError {
+    case notAuthorized
+    case searchError
+
+    public var errorDescription: String? {
+        switch self {
+            case .notAuthorized:
+                "에플 뮤직에 접근하는 권한이 없습니다."
+            case .searchError:
+                "노래 검색 중 오류가 발생했습니다."
         }
     }
 }

--- a/alsongDalsong/ASMusicKit/ASMusicKit/CGColor+Hex.swift
+++ b/alsongDalsong/ASMusicKit/ASMusicKit/CGColor+Hex.swift
@@ -1,0 +1,30 @@
+import CoreGraphics
+
+extension CGColor {
+    func toHex() -> String? {
+        guard let components = components, components.count >= 3 else {
+            return nil
+        }
+        let r = components[0]
+        let g = components[1]
+        let b = components[2]
+
+        var a: CGFloat = 1.0
+        if components.count >= 4 {
+            a = components[3]
+        }
+
+        if a != 1.0 {
+            return String(format: "#%02X%02X%02X%02X",
+                          Int(r * 255),
+                          Int(g * 255),
+                          Int(b * 255),
+                          Int(a * 255))
+        } else {
+            return String(format: "#%02X%02X%02X",
+                          Int(r * 255),
+                          Int(g * 255),
+                          Int(b * 255))
+        }
+    }
+}

--- a/alsongDalsong/ASNetworkKit/ASNetworkKit/ASNetworkErrors.swift
+++ b/alsongDalsong/ASNetworkKit/ASNetworkKit/ASNetworkErrors.swift
@@ -1,14 +1,14 @@
 import Foundation
 
-public enum ASNetworkErrors: Error, CustomStringConvertible {
+public enum ASNetworkErrors: Error, LocalizedError {
     case serverError(message: String)
     case urlError
     case responseError
     case FirebaseSignInError
     case FirebaseSignOutError
     case FirebaseListenerError
-
-    public var description: String {
+    
+    public var errorDescription: String? {
         switch self {
             case let .serverError(message: message):
                 return message

--- a/alsongDalsong/ASRepository/ASRepository/Protocols/RepositoryProtocols.swift
+++ b/alsongDalsong/ASRepository/ASRepository/Protocols/RepositoryProtocols.swift
@@ -59,7 +59,7 @@ public protocol RoomActionRepositoryProtocol {
 }
 
 public protocol MusicRepositoryProtocol {
-    func getMusicData(url: URL) -> Future<Data?, Error>
+    func getMusicData(url: URL) async -> Data?
 }
 
 public protocol GameStateRepositoryProtocol {

--- a/alsongDalsong/ASRepository/ASRepository/Repositories/GameStateRepository.swift
+++ b/alsongDalsong/ASRepository/ASRepository/Repositories/GameStateRepository.swift
@@ -13,8 +13,7 @@ public final class GameStateRepository: GameStateRepositoryProtocol {
         Publishers.CombineLatest4(mainRepository.mode, mainRepository.recordOrder, mainRepository.status, mainRepository.round)
             .receive(on: DispatchQueue.main)
             .map { mode, recordOrder, status, round in
-                guard let mode, let round else { return nil }
-                guard let players: [ASEntity.Player] = self.mainRepository.players.value else { return nil }
+                guard let mode, let round, let players = self.mainRepository.players.value else { return nil }
                 return ASEntity.GameState(mode: mode, recordOrder: recordOrder, status: status, round: round, players: players)
             }
             .eraseToAnyPublisher()

--- a/alsongDalsong/ASRepository/ASRepository/Repositories/GameStateRepository.swift
+++ b/alsongDalsong/ASRepository/ASRepository/Repositories/GameStateRepository.swift
@@ -8,13 +8,14 @@ public final class GameStateRepository: GameStateRepositoryProtocol {
     public init(mainRepository: MainRepositoryProtocol) {
         self.mainRepository = mainRepository
     }
-    
+
     public func getGameState() -> AnyPublisher<ASEntity.GameState?, Never> {
         Publishers.CombineLatest4(mainRepository.mode, mainRepository.recordOrder, mainRepository.status, mainRepository.round)
             .receive(on: DispatchQueue.main)
             .map { mode, recordOrder, status, round in
                 guard let mode, let round else { return nil }
-                return ASEntity.GameState(mode: mode, recordOrder: recordOrder, status: status, round: round)
+                guard let players: [ASEntity.Player] = self.mainRepository.players.value else { return nil }
+                return ASEntity.GameState(mode: mode, recordOrder: recordOrder, status: status, round: round, players: players)
             }
             .eraseToAnyPublisher()
     }

--- a/alsongDalsong/ASRepository/ASRepository/Repositories/MainRepository.swift
+++ b/alsongDalsong/ASRepository/ASRepository/Repositories/MainRepository.swift
@@ -6,7 +6,7 @@ import Combine
 import Foundation
 
 public final class MainRepository: MainRepositoryProtocol {
-    public var myId = ASFirebaseAuth.myID
+    public var myId: String? { ASFirebaseAuth.myID }
     public var number = CurrentValueSubject<String?, Never>(nil)
     public var host = CurrentValueSubject<Player?, Never>(nil)
     public var players = CurrentValueSubject<[Player]?, Never>(nil)
@@ -41,19 +41,19 @@ public final class MainRepository: MainRepositoryProtocol {
                         return
                 }
             } receiveValue: { [weak self] room in
-                guard let self = self else { return }
-                self.update(\.number, with: room.number)
-                self.update(\.host, with: room.host)
-                self.update(\.players, with: room.players)
-                self.update(\.mode, with: room.mode)
-                self.update(\.round, with: room.round)
-                self.update(\.status, with: room.status)
-                self.update(\.recordOrder, with: room.recordOrder)
-                self.update(\.answers, with: room.answers)
-                self.update(\.dueTime, with: room.dueTime)
-                self.update(\.submits, with: room.submits)
-                self.update(\.records, with: room.records)
-                self.update(\.selectedRecords, with: room.selectedRecords)
+                guard let self else { return }
+                update(\.number, with: room.number)
+                update(\.host, with: room.host)
+                update(\.players, with: room.players)
+                update(\.mode, with: room.mode)
+                update(\.round, with: room.round)
+                update(\.status, with: room.status)
+                update(\.recordOrder, with: room.recordOrder)
+                update(\.answers, with: room.answers)
+                update(\.dueTime, with: room.dueTime)
+                update(\.submits, with: room.submits)
+                update(\.records, with: room.records)
+                update(\.selectedRecords, with: room.selectedRecords)
             }
             .store(in: &cancellables)
     }

--- a/alsongDalsong/ASRepository/ASRepository/Repositories/MusicRepository.swift
+++ b/alsongDalsong/ASRepository/ASRepository/Repositories/MusicRepository.swift
@@ -15,23 +15,13 @@ public final class MusicRepository: MusicRepositoryProtocol {
         self.networkManager = networkManager
     }
 
-    public func getMusicData(url: URL) -> Future<Data?, Error> {
-        Future { promise in
-            Task {
-                do {
-                    guard let endpoint = ResourceEndpoint(url: url)
-                    else { return promise(.failure(ASNetworkErrors.urlError)) }
-                    let data = try await self.networkManager.sendRequest(
-                        to: endpoint,
-                        type: .json,
-                        body: nil,
-                        option: .both
-                    )
-                    promise(.success(data))
-                } catch {
-                    promise(.failure(error))
-                }
-            }
+    public func getMusicData(url: URL) async -> Data? {
+        do {
+            guard let endpoint = ResourceEndpoint(url: url) else { return nil }
+            let data = try await self.networkManager.sendRequest(to: endpoint, type: .json, body: nil, option: .both)
+            return data
+        } catch {
+            return nil
         }
     }
 }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/ASAlertController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/ASAlertController.swift
@@ -310,6 +310,7 @@ enum ASAlertText {
         case joinRoom
         case joinFailed
         case createFailed
+        case submitFailld
 
         var description: String {
             switch self {
@@ -317,6 +318,7 @@ enum ASAlertText {
                 case .joinRoom: "게임 입장 코드를 입력하세요"
                 case .joinFailed: "참가에 실패하였습니다."
                 case .createFailed: "생성에 실패하였습니다."
+                case .submitFailld: "제출에 실패하였습니다."
             }
         }
     }
@@ -349,10 +351,13 @@ enum ASAlertText {
 
     enum ProgressText: CustomStringConvertible {
         case joinRoom
+        case submitMusic
 
         var description: String {
             switch self {
                 case .joinRoom: "방 정보를 가져오는 중..."
+                case .submitMusic: "노래를 전송하는 중..."
+                
             }
         }
     }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/ASAlertController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/ASAlertController.swift
@@ -399,11 +399,13 @@ enum ASAlertText {
         case joinRoom
         case startGame
         case submitMusic
+        case submitHumming
         var description: String {
             switch self {
                 case .joinRoom: "방 정보를 가져오는 중..."
                 case .startGame: "게임을 시작하는 중..."
                 case .submitMusic: "노래를 전송하는 중..."
+                case .submitHumming: "허밍을 전송하는 중..."
             }
         }
     }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/ASAlertController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/ASAlertController.swift
@@ -310,6 +310,7 @@ enum ASAlertText {
         case joinRoom
         case joinFailed
         case createFailed
+        case stratGameFailed
         case submitFailld
 
         var description: String {
@@ -318,6 +319,7 @@ enum ASAlertText {
                 case .joinRoom: "게임 입장 코드를 입력하세요"
                 case .joinFailed: "참가에 실패하였습니다."
                 case .createFailed: "생성에 실패하였습니다."
+                case .stratGameFailed: "게임 시작에 실패하였습니다."
                 case .submitFailld: "제출에 실패하였습니다."
             }
         }
@@ -351,13 +353,13 @@ enum ASAlertText {
 
     enum ProgressText: CustomStringConvertible {
         case joinRoom
+        case startGame
         case submitMusic
-
         var description: String {
             switch self {
                 case .joinRoom: "방 정보를 가져오는 중..."
+                case .startGame: "게임을 시작하는 중..."
                 case .submitMusic: "노래를 전송하는 중..."
-                
             }
         }
     }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/ProgressBar.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/ProgressBar.swift
@@ -62,6 +62,7 @@ final class ProgressBar: UIView {
     private func startProgressAnimation() {
         guard let targetDate else { return }
         let timeInterval = targetDate.timeIntervalSince(Date.now)
+        if timeInterval < 50 { return }
         cancellables.forEach { $0.cancel() }
         cancellables.removeAll()
 

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Extensions/Color+Hex.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Extensions/Color+Hex.swift
@@ -1,0 +1,39 @@
+import SwiftUI
+
+extension Color {
+    init(hex: String) {
+        let hex = hex.trimmingCharacters(in: CharacterSet.alphanumerics.inverted)
+        var int: UInt64 = 0
+        
+        Scanner(string: hex).scanHexInt64(&int)
+        
+        let a, r, g, b: UInt64
+        switch hex.count {
+        case 3: // RGB (12-bit)
+            (a, r, g, b) = (255,
+                            (int >> 8) * 17,
+                            (int >> 4 & 0xF) * 17,
+                            (int & 0xF) * 17)
+        case 6: // RGB (24-bit)
+            (a, r, g, b) = (255,
+                            int >> 16,
+                            int >> 8 & 0xFF,
+                            int & 0xFF)
+        case 8: // ARGB (32-bit)
+            (a, r, g, b) = (int >> 24,
+                            int >> 16 & 0xFF,
+                            int >> 8 & 0xFF,
+                            int & 0xFF)
+        default:
+            (a, r, g, b) = (255, 0, 0, 0) // 기본값: 검정색
+        }
+        
+        self.init(
+            .sRGB,
+            red: Double(r) / 255,
+            green: Double(g) / 255,
+            blue: Double(b) / 255,
+            opacity: Double(a) / 255
+        )
+    }
+}

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Game/GameNavigationController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Game/GameNavigationController.swift
@@ -42,12 +42,14 @@ final class GameNavigationController {
     private func updateViewControllers(state: GameState) {
         let viewType = state.resolveViewType()
         switch viewType {
-        case .selectMusic:
+        case .submitMusic:
             navigateToSelectMusic()
         case .humming:
             navigateToHumming()
         case .rehumming:
             navigateToRehumming()
+        case .submitAnswer:
+            navigateToSubmitAnswer()
         case .result:
             navigateToResult()
         case .lobby:
@@ -123,6 +125,24 @@ final class GameNavigationController {
             recordsRepository: recordsRepository
         )
         let vc = RehummingViewController(viewModel: vm)
+        navigationController.pushViewController(vc, animated: true)
+    }
+    
+    private func navigateToSubmitAnswer() {
+        let gameStatusRepository = DIContainer.shared.resolve(GameStatusRepositoryProtocol.self)
+        let playersRepository = DIContainer.shared.resolve(PlayersRepositoryProtocol.self)
+        let recordsRepository = DIContainer.shared.resolve(RecordsRepositoryProtocol.self)
+        let submitsRepository = DIContainer.shared.resolve(SubmitsRepositoryProtocol.self)
+        let musicRepository = DIContainer.shared.resolve(MusicRepositoryProtocol.self)
+        
+        let vm = SubmitAnswerViewModel(
+            gameStatusRepository: gameStatusRepository,
+            playersRepository: playersRepository,
+            recordsRepository: recordsRepository,
+            submitsRepository: submitsRepository,
+            musicRepository: musicRepository
+        )
+        let vc = SubmitAnswerViewController(viewModel: vm)
         navigationController.pushViewController(vc, animated: true)
     }
     

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Humming/HummingView.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Humming/HummingView.swift
@@ -111,6 +111,7 @@ final class HummingViewController: UIViewController {
 
     private func submitHumming() async throws {
         do {
+            progressBar.cancelCompletion()
             try await viewModel.submitHumming()
         } catch {
             throw ASAlertError.submitFailed

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Humming/HummingView.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Humming/HummingView.swift
@@ -52,17 +52,7 @@ final class HummingViewController: UIViewController {
         submitButton.setConfiguration(title: "녹음 완료", backgroundColor: .asLightGray)
         submitButton.addAction(
             UIAction { [weak self] _ in
-                self?.vm.submitHumming()
-                let gameStatusRepository = DIContainer.shared.resolve(GameStatusRepositoryProtocol.self)
-                let playersRepository = DIContainer.shared.resolve(PlayersRepositoryProtocol.self)
-                let recordsRepository = DIContainer.shared.resolve(RecordsRepositoryProtocol.self)
-                let vm = RehummingViewModel(
-                    gameStatusRepository: gameStatusRepository,
-                    playersRepository: playersRepository,
-                    recordsRepository: recordsRepository
-                )
-                let vc = RehummingViewController(vm: vm)
-                self?.navigationController?.pushViewController(vc, animated: true)
+                self?.showSubmitHummingLoading()
             }, for: .touchUpInside
         )
         submitButton.updateButton(.disabled)
@@ -107,11 +97,39 @@ final class HummingViewController: UIViewController {
 
             submissionStatus.topAnchor.constraint(equalTo: buttonStack.topAnchor, constant: -16),
             submissionStatus.trailingAnchor.constraint(equalTo: buttonStack.trailingAnchor, constant: 16),
-            
+
             buttonStack.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -24),
             buttonStack.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 24),
             buttonStack.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -24),
             buttonStack.heightAnchor.constraint(equalToConstant: 64),
         ])
+    }
+
+    private func submitHumming() async throws {
+        do {
+            try await vm.submitHumming()
+        } catch {
+            throw ASAlertError.submitFailed
+        }
+    }
+}
+
+// MARK: - Alert
+
+extension HummingViewController {
+    func showSubmitHummingLoading() {
+        let alert = ASAlertController(
+            progressText: .submitHumming)
+        { [weak self] in
+            try await self?.submitHumming()
+        } errorCompletion: { [weak self] in
+            self?.showFailSubmitMusic()
+        }
+        presentLoadingView(alert)
+    }
+
+    func showFailSubmitMusic() {
+        let alert = ASAlertController(errorType: .submitFailed)
+        presentAlert(alert)
     }
 }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Humming/HummingView.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Humming/HummingView.swift
@@ -111,9 +111,11 @@ final class HummingViewController: UIViewController {
 
     private func submitHumming() async throws {
         do {
+            submitButton.updateButton(.disabled)
             progressBar.cancelCompletion()
             try await viewModel.submitHumming()
         } catch {
+            submitButton.updateButton(.complete)
             throw ASAlertError.submitFailed
         }
     }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Humming/HummingView.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Humming/HummingView.swift
@@ -115,8 +115,7 @@ final class HummingViewController: UIViewController {
             progressBar.cancelCompletion()
             try await viewModel.submitHumming()
         } catch {
-            submitButton.updateButton(.complete)
-            throw ASAlertError.submitFailed
+            throw error
         }
     }
 }
@@ -124,19 +123,23 @@ final class HummingViewController: UIViewController {
 // MARK: - Alert
 
 extension HummingViewController {
-    func showSubmitHummingLoading() {
+    private func showSubmitHummingLoading() {
         let alert = ASAlertController(
-            progressText: .submitHumming)
-        { [weak self] in
-            try await self?.submitHumming()
-        } errorCompletion: { [weak self] in
-            self?.showFailSubmitMusic()
-        }
+            progressText: .submitHumming,
+            load:
+                { [weak self] in
+                    try await self?.submitHumming()
+                },
+            errorCompletion: { [weak self] error in
+            self?.showFailSubmitMusic(error)
+        })
         presentLoadingView(alert)
     }
 
-    func showFailSubmitMusic() {
-        let alert = ASAlertController(errorType: .submitFailed)
+    private func showFailSubmitMusic(_ error: Error) {
+        let alert = ASAlertController(titleText: .error(error)) { [weak self] _ in
+            self?.submitButton.updateButton(.complete)
+        }
         presentAlert(alert)
     }
 }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Humming/HummingViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Humming/HummingViewModel.swift
@@ -33,19 +33,17 @@ final class HummingViewModel: @unchecked Sendable {
         bindAnswer()
     }
 
-    func submitHumming() {
+    func submitHumming() async throws {
         guard let recordedData else { return }
-        Task {
-            do {
-                let result = try await recordsRepository.uploadRecording(recordedData)
-                if result {
-                    // 전송됨
-                } else {
-                    // 전송 안됨, 오류 alert
-                }
-            } catch {
+        do {
+            let result = try await recordsRepository.uploadRecording(recordedData)
+            if result {
+                // 전송됨
+            } else {
                 // 전송 안됨, 오류 alert
             }
+        } catch {
+            throw error
         }
     }
 

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Lobby/LobbyViewController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Lobby/LobbyViewController.swift
@@ -163,11 +163,11 @@ final class LobbyViewController: UIViewController {
         ])
     }
     
-    private func gameStart() async {
+    private func gameStart() async throws{
         do {
             try await self.viewmodel.gameStart()
         } catch {
-            showStartGameFailed()
+            throw ASAlertError.stratGameFailed
         }
     }
 }
@@ -176,14 +176,16 @@ final class LobbyViewController: UIViewController {
 
 extension LobbyViewController {
     func showStartGameLoading() {
-        let alert = ASAlertController(progressText: .startGame) { [weak self] in
-            await self?.gameStart()
-        }
+        let alert = ASAlertController(progressText: .startGame, load: { [weak self] in
+            try await self?.gameStart()
+        }, errorCompletion: { [weak self] in
+            self?.showStartGameFailed()
+        })
         presentLoadingView(alert)
     }
     
     func showStartGameFailed() {
-        let alert = ASAlertController(titleText: .stratGameFailed)
+        let alert = ASAlertController(errorType: .stratGameFailed)
         presentAlert(alert)
     }
 }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Lobby/LobbyViewController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Lobby/LobbyViewController.swift
@@ -165,9 +165,10 @@ final class LobbyViewController: UIViewController {
     
     private func gameStart() async throws{
         do {
+            startButton.updateButton(.disabled)
             try await self.viewmodel.gameStart()
         } catch {
-            throw ASAlertError.stratGameFailed
+            throw error
         }
     }
 }
@@ -176,16 +177,22 @@ final class LobbyViewController: UIViewController {
 
 extension LobbyViewController {
     func showStartGameLoading() {
-        let alert = ASAlertController(progressText: .startGame, load: { [weak self] in
-            try await self?.gameStart()
-        }, errorCompletion: { [weak self] in
-            self?.showStartGameFailed()
+        let alert = ASAlertController(
+            progressText: .startGame,
+            load: { [weak self] in
+                try await self?.gameStart()
+            },
+            errorCompletion: { [weak self] error in
+            self?.showStartGameFailed(error)
         })
         presentLoadingView(alert)
     }
     
-    func showStartGameFailed() {
-        let alert = ASAlertController(errorType: .stratGameFailed)
+    func showStartGameFailed(_ error: Error) {
+        let alert = ASAlertController(titleText: .error(error)) { [weak self] _ in
+            print("?")
+            self?.startButton.updateButton(.complete)
+        }
         presentAlert(alert)
     }
 }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Lobby/LobbyViewController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Lobby/LobbyViewController.swift
@@ -114,7 +114,7 @@ final class LobbyViewController: UIViewController {
         }, for: .touchUpInside)
         
         startButton.addAction(UIAction { [weak self] _ in
-            self?.viewmodel.gameStart()
+            self?.showStartGameLoading()
         }, for: .touchUpInside)
     }
     
@@ -161,5 +161,29 @@ final class LobbyViewController: UIViewController {
             startButton.trailingAnchor.constraint(equalTo: safeArea.trailingAnchor, constant: -24),
             startButton.heightAnchor.constraint(equalToConstant: 64)
         ])
+    }
+    
+    private func gameStart() async {
+        do {
+            try await self.viewmodel.gameStart()
+        } catch {
+            showStartGameFailed()
+        }
+    }
+}
+
+// MARK: - Alert
+
+extension LobbyViewController {
+    func showStartGameLoading() {
+        let alert = ASAlertController(progressText: .startGame) { [weak self] in
+            await self?.gameStart()
+        }
+        presentLoadingView(alert)
+    }
+    
+    func showStartGameFailed() {
+        let alert = ASAlertController(titleText: .stratGameFailed)
+        presentAlert(alert)
     }
 }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Lobby/LobbyViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Lobby/LobbyViewModel.swift
@@ -112,7 +112,7 @@ final class LobbyViewModel: ObservableObject, @unchecked Sendable {
         Task {
             do {
                 if isHost {
-                    try await self.roomActionRepository.changeMode(roomNumber: roomNumber, mode: mode)
+                    _ = try await self.roomActionRepository.changeMode(roomNumber: roomNumber, mode: mode)
                 }
             } catch {
                 print(error.localizedDescription)

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Lobby/LobbyViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Lobby/LobbyViewModel.swift
@@ -1,5 +1,6 @@
 import ASEntity
 import ASRepository
+import ASNetworkKit
 import Combine
 import Foundation
 
@@ -91,7 +92,11 @@ final class LobbyViewModel: ObservableObject, @unchecked Sendable {
     }
     
     func gameStart() async throws {
-        let isGameStarted = try await roomActionRepository.startGame(roomNumber: roomNumber)
+        do {
+            let _ = try await roomActionRepository.startGame(roomNumber: roomNumber)
+        } catch {
+            throw error
+        }
     }
     
     func leaveRoom() {

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Lobby/LobbyViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Lobby/LobbyViewModel.swift
@@ -1,6 +1,5 @@
 import ASEntity
 import ASRepository
-import ASNetworkKit
 import Combine
 import Foundation
 

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Lobby/LobbyViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Lobby/LobbyViewModel.swift
@@ -90,14 +90,8 @@ final class LobbyViewModel: ObservableObject, @unchecked Sendable {
             .store(in: &cancellables)
     }
     
-    func gameStart() {
-        Task {
-            do {
-                let isGameStarted = try await roomActionRepository.startGame(roomNumber: roomNumber)
-            } catch {
-                print(error.localizedDescription)
-            }
-        }
+    func gameStart() async throws {
+        let isGameStarted = try await roomActionRepository.startGame(roomNumber: roomNumber)
     }
     
     func leaveRoom() {

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/MusicPanel/MusicPanelViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/MusicPanel/MusicPanelViewModel.swift
@@ -3,7 +3,7 @@ import ASEntity
 import Combine
 import ASRepository
 
-final class MusicPanelViewModel {
+final class MusicPanelViewModel: @unchecked Sendable {
     @Published var music: Music?
     @Published var artwork: Data?
     @Published var preview: Data?
@@ -19,36 +19,16 @@ final class MusicPanelViewModel {
 
     private func getPreviewData() {
         guard let previewUrl = music?.previewUrl else { return }
-        musicRepository?.getMusicData(url: previewUrl)
-            .receive(on: DispatchQueue.main)
-            .sink { completion in
-                switch completion {
-                    case .finished:
-                        break
-                    case let .failure(error):
-                        print(error.localizedDescription)
-                }
-            } receiveValue: { [weak self] preview in
-                self?.preview = preview
-            }
-            .store(in: &cancellables)
+        Task {
+            preview = await musicRepository?.getMusicData(url: previewUrl)
+        }
     }
 
     private func getArtworkData() {
         guard let artworkUrl = music?.artworkUrl else { return }
-        musicRepository?.getMusicData(url: artworkUrl)
-            .receive(on: DispatchQueue.main)
-            .sink { completion in
-                switch completion {
-                    case .finished:
-                        break
-                    case let .failure(error):
-                        print(error.localizedDescription)
-                }
-            } receiveValue: { [weak self] artwork in
-                self?.artwork = artwork
-            }
-            .store(in: &cancellables)
+        Task {
+            artwork = await musicRepository?.getMusicData(url: artworkUrl)
+        }
     }
 
     @MainActor

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Onboarding/OnboardingViewController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Onboarding/OnboardingViewController.swift
@@ -1,5 +1,4 @@
 import ASContainer
-import ASNetworkKit
 import ASRepository
 import Combine
 import UIKit

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Onboarding/OnboardingViewController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Onboarding/OnboardingViewController.swift
@@ -174,17 +174,13 @@ final class OnboardingViewController: UIViewController {
 
     private func joinRoom(with roomNumber: String) {
         Task {
-            guard let number = await viewModel?.joinRoom(roomNumber: roomNumber),
-                  !number.isEmpty
-            else {
-                if createRoomButton.isHidden {
-                    createRoomButton.isHidden = true
-                }
-                showJoinRoomFailedAlert()
-                return
+            do {
+                let number = try await viewModel?.joinRoom(roomNumber: roomNumber)
+                guard let number, !number.isEmpty else { return }
+                navigateToLobby(with: number)
+            } catch {
+                showRoomFailedAlert(error)
             }
-            inviteCode = ""
-            navigateToLobby(with: number)
         }
     }
 
@@ -206,8 +202,13 @@ final class OnboardingViewController: UIViewController {
         if let nickname = nickNamePanel.text, !nickname.isEmpty {
             viewModel?.setNickname(with: nickname)
         }
-        guard let number = try await viewModel?.createRoom() else { throw ASAlertError.createFailed }
-        navigateToLobby(with: number)
+        do {
+            let number = try await viewModel?.createRoom()
+            guard let number else { return }
+            navigateToLobby(with: number)
+        } catch {
+            throw error
+        }
     }
 }
 
@@ -222,7 +223,7 @@ extension OnboardingViewController {
 // MARK: - Alert
 
 extension OnboardingViewController {
-    func showRoomNumerInputAlert() {
+    private func showRoomNumerInputAlert() {
         let alert = ASAlertController(
             titleText: .joinRoom,
             textFieldPlaceholder: .roomNumber,
@@ -233,22 +234,21 @@ extension OnboardingViewController {
         presentAlert(alert)
     }
 
-    func showJoinRoomFailedAlert() {
-        let alert = ASAlertController(errorType: .joinFailed)
+    private func showRoomFailedAlert(_ error: Error) {
+        let alert = ASAlertController(titleText: .error(error))
         presentAlert(alert)
     }
 
-    func showCreateRoomFailedAlert() {
-        let alert = ASAlertController(errorType: .createFailed)
-        presentAlert(alert)
-    }
-
-    func showCreateRoomLoading() {
-        let alert = ASAlertController(progressText: .joinRoom, load: { [weak self] in
-            try await self?.setNicknameAndCreateRoom()
-        }, errorCompletion: { [weak self] in
-            self?.showCreateRoomFailedAlert()
-        })
+    private func showCreateRoomLoading() {
+        let alert = ASAlertController(
+            progressText: .joinRoom,
+            load: { [weak self] in
+                try await self?.setNicknameAndCreateRoom()
+            },
+            errorCompletion: { [weak self] error in
+                self?.showRoomFailedAlert(error)
+            }
+        )
         presentLoadingView(alert)
     }
 }
@@ -256,7 +256,7 @@ extension OnboardingViewController {
 // MARK: - KeyboardObserve
 
 private extension OnboardingViewController {
-    func observeKeyboard() {
+    private func observeKeyboard() {
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(keyboardWillShow(_:)),

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Onboarding/OnboardingViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Onboarding/OnboardingViewModel.swift
@@ -1,4 +1,3 @@
-import ASNetworkKit
 import ASRepository
 import Combine
 import Foundation
@@ -79,7 +78,7 @@ final class OnboardingViewModel: @unchecked Sendable {
     }
 
     @MainActor
-    func createRoom() async -> String? {
+    func createRoom() async throws -> String? {
         guard let selectedAvatar else { return nil }
         buttonEnabled = false
         do {
@@ -87,7 +86,7 @@ final class OnboardingViewModel: @unchecked Sendable {
             return await joinRoom(roomNumber: roomNumber)
         } catch {
             buttonEnabled = true
-            return nil
+            throw error
         }
     }
 }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Onboarding/OnboardingViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Onboarding/OnboardingViewModel.swift
@@ -65,7 +65,7 @@ final class OnboardingViewModel: @unchecked Sendable {
     }
 
     @MainActor
-    func joinRoom(roomNumber id: String) async -> String? {
+    func joinRoom(roomNumber id: String) async throws -> String? {
         guard let selectedAvatar else { return nil }
         buttonEnabled = false
         do {
@@ -73,7 +73,7 @@ final class OnboardingViewModel: @unchecked Sendable {
             return id
         } catch {
             buttonEnabled = true
-            return nil
+            throw error
         }
     }
 
@@ -83,7 +83,7 @@ final class OnboardingViewModel: @unchecked Sendable {
         buttonEnabled = false
         do {
             let roomNumber = try await roomActionRepository.createRoom(nickname: nickname, avatar: selectedAvatar)
-            return await joinRoom(roomNumber: roomNumber)
+            return try await joinRoom(roomNumber: roomNumber)
         } catch {
             buttonEnabled = true
             throw error

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Rehumming/RehummingView.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Rehumming/RehummingView.swift
@@ -116,8 +116,7 @@ final class RehummingViewController: UIViewController {
             progressBar.cancelCompletion()
             try await viewModel.submitHumming()
         } catch {
-            submitButton.updateButton(.complete)
-            throw ASAlertError.submitFailed
+            throw error
         }
     }
 }
@@ -125,19 +124,23 @@ final class RehummingViewController: UIViewController {
 // MARK: - Alert
 
 extension RehummingViewController {
-    func showSubmitHummingLoading() {
+    private func showSubmitHummingLoading() {
         let alert = ASAlertController(
-            progressText: .submitHumming)
-        { [weak self] in
-            try await self?.submitHumming()
-        } errorCompletion: { [weak self] in
-            self?.showFailSubmitMusic()
-        }
+            progressText: .submitHumming,
+            load:
+                { [weak self] in
+                    try await self?.submitHumming()
+                },
+            errorCompletion: { [weak self] error in
+            self?.showFailSubmitMusic(error)
+        })
         presentLoadingView(alert)
     }
 
-    func showFailSubmitMusic() {
-        let alert = ASAlertController(errorType: .submitFailed)
+    private func showFailSubmitMusic(_ error: Error) {
+        let alert = ASAlertController(titleText: .error(error)) { [weak self] _ in
+            self?.submitButton.updateButton(.complete)
+        }
         presentAlert(alert)
     }
 }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Rehumming/RehummingView.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Rehumming/RehummingView.swift
@@ -112,9 +112,11 @@ final class RehummingViewController: UIViewController {
     
     private func submitHumming() async throws {
         do {
+            submitButton.updateButton(.disabled)
             progressBar.cancelCompletion()
             try await viewModel.submitHumming()
         } catch {
+            submitButton.updateButton(.complete)
             throw ASAlertError.submitFailed
         }
     }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Rehumming/RehummingView.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Rehumming/RehummingView.swift
@@ -112,6 +112,7 @@ final class RehummingViewController: UIViewController {
     
     private func submitHumming() async throws {
         do {
+            progressBar.cancelCompletion()
             try await viewModel.submitHumming()
         } catch {
             throw ASAlertError.submitFailed

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Rehumming/RehummingViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Rehumming/RehummingViewModel.swift
@@ -29,19 +29,17 @@ final class RehummingViewModel: @unchecked Sendable {
         bindSubmitStatus()
     }
 
-    func submitHumming() {
+    func submitHumming() async throws {
         guard let recordedData else { return }
-        Task {
-            do {
-                let result = try await recordsRepository.uploadRecording(recordedData)
-                if result {
-                    // 전송됨
-                } else {
-                    // 전송 안됨, 오류 alert
-                }
-            } catch {
+        do {
+            let result = try await recordsRepository.uploadRecording(recordedData)
+            if result {
+                // 전송됨
+            } else {
                 // 전송 안됨, 오류 alert
             }
+        } catch {
+            throw error
         }
     }
 

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SelectMusic/ASMusicItemCell.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SelectMusic/ASMusicItemCell.swift
@@ -1,14 +1,24 @@
+import ASEntity
 import MusicKit
 import SwiftUI
 
 struct ASMusicItemCell: View {
-    let artwork: Artwork?
-    let title: String
-    let artist: String
+    @State private var artworkData: Data?
+    let music: Music?
+    let fetchArtwork: (URL?) async -> Data?
+
     var body: some View {
         HStack {
-            if let artwork {
-                ArtworkImage(artwork, width: 60)
+            if let artworkData, let uiImage = UIImage(data: artworkData) {
+                Image(uiImage: uiImage)
+                    .resizable()
+                    .frame(width: 60, height: 60)
+                    .clipShape(RoundedRectangle(cornerRadius: 4))
+                    .padding(.horizontal, 8)
+            } else if let music, let artworkColor = music.artworkBackgroundColor {
+                Rectangle()
+                    .foregroundColor(Color(hex: artworkColor))
+                    .frame(width: 60, height: 60)
                     .clipShape(RoundedRectangle(cornerRadius: 4))
                     .padding(.horizontal, 8)
             } else {
@@ -16,19 +26,25 @@ struct ASMusicItemCell: View {
                     .frame(width: 60, height: 60)
                     .background(.asSystem)
                     .clipShape(RoundedRectangle(cornerRadius: 4))
-                    .padding()
+                    .padding(.horizontal, 8)
             }
             VStack(alignment: .leading) {
-                Text(title)
+                Text(music?.title ?? "선택된 곡 없음")
                     .font(.custom("DoHyeon-Regular", size: 16))
-                Text(artist)
+                Text(music?.artist ?? "아티스트")
                     .foregroundStyle(.gray)
                     .font(.custom("DoHyeon-Regular", size: 16))
+            }
+        }
+        .task(id: music) {
+            artworkData = nil
+            if let music {
+                artworkData = await fetchArtwork(music.artworkUrl)
             }
         }
     }
 }
 
 #Preview {
-    ASMusicItemCell(artwork: nil, title: "Dumb Dumb", artist: "레드벨벳")
+    ASMusicItemCell(music: Music()) { _ in nil }
 }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SelectMusic/ASMusicItemCell.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SelectMusic/ASMusicItemCell.swift
@@ -31,9 +31,11 @@ struct ASMusicItemCell: View {
             VStack(alignment: .leading) {
                 Text(music?.title ?? "선택된 곡 없음")
                     .font(.custom("DoHyeon-Regular", size: 16))
+                    .lineLimit(1)
                 Text(music?.artist ?? "아티스트")
                     .foregroundStyle(.gray)
                     .font(.custom("DoHyeon-Regular", size: 16))
+                    .lineLimit(1)
             }
         }
         .task(id: music) {

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SelectMusic/SelectMusicView.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SelectMusic/SelectMusicView.swift
@@ -24,7 +24,9 @@ struct SelectMusicView: View {
 
             ASSearchBar(text: $searchTerm, placeHolder: "곡 제목을 검색하세요")
                 .onChange(of: searchTerm) { newValue in
-                    viewModel.searchMusic(text: newValue)
+                    Task {
+                        viewModel.searchMusic(text: newValue)
+                    }
                 }
             if searchTerm == "" {
                 VStack(alignment: .center) {

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SelectMusic/SelectMusicView.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SelectMusic/SelectMusicView.swift
@@ -25,7 +25,9 @@ struct SelectMusicView: View {
 
             ASSearchBar(text: $searchTerm, placeHolder: "곡 제목을 검색하세요")
                 .onChange(of: searchTerm) { newValue in
-                    viewModel.searchMusic(text: newValue)
+                    Task {
+                        try await viewModel.searchMusic(text: newValue)
+                    }
                 }
             if searchTerm == "" {
                 VStack(alignment: .center) {

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SelectMusic/SelectMusicView.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SelectMusic/SelectMusicView.swift
@@ -7,8 +7,9 @@ struct SelectMusicView: View {
     var body: some View {
         VStack {
             HStack {
-                ASMusicItemCell(artwork: viewModel.selectedSong.artwork, title: viewModel.selectedSong.title, artist: viewModel.selectedSong.artistName)
-                    .padding(EdgeInsets(top: 4, leading: 32, bottom: 4, trailing: 32))
+                ASMusicItemCell(music: viewModel.selectedMusic, fetchArtwork: { url in
+                    await viewModel.downloadArtwork(url: url)
+                })
                 Spacer()
                 Button {
                     viewModel.isPlaying.toggle()
@@ -24,9 +25,7 @@ struct SelectMusicView: View {
 
             ASSearchBar(text: $searchTerm, placeHolder: "곡 제목을 검색하세요")
                 .onChange(of: searchTerm) { newValue in
-                    Task {
-                        viewModel.searchMusic(text: newValue)
-                    }
+                    viewModel.searchMusic(text: newValue)
                 }
             if searchTerm == "" {
                 VStack(alignment: .center) {
@@ -36,12 +35,14 @@ struct SelectMusicView: View {
                     Spacer()
                 }
             }
-            List(viewModel.searchList) { song in
+            List(viewModel.searchList) { music in
                 Button {
-                    viewModel.handleSelectedSong(song: song)
+                    viewModel.handleSelectedSong(with: music)
                 } label: {
-                    ASMusicItemCell(artwork: song.artwork, title: song.title, artist: song.artistName)
-                        .tint(.black)
+                    ASMusicItemCell(music: music, fetchArtwork: { url in
+                        await viewModel.downloadArtwork(url: url)
+                    })
+                    .tint(.black)
                 }
             }
             .listStyle(.plain)

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SelectMusic/SelectMusicViewController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SelectMusic/SelectMusicViewController.swift
@@ -33,13 +33,13 @@ class SelectMusicViewController: UIViewController {
         selectCompleteButton.bind(to: viewModel.$musicData)
     }
     
-    func setupUI() {
+    private func setupUI() {
         view.backgroundColor = .asLightGray
         selectCompleteButton.setConfiguration(title: "선택 완료", backgroundColor: .asGreen)
         selectCompleteButton.isEnabled = false
     }
     
-    func setupLayout() {
+    private func setupLayout() {
         let musicView = SelectMusicView(viewModel: viewModel)
         selectMusicView = UIHostingController(rootView: musicView)
         guard let selectMusicView else { return }
@@ -72,7 +72,7 @@ class SelectMusicViewController: UIViewController {
         ])
     }
     
-    func setAction() {
+    private func setAction() {
         selectCompleteButton.addAction(UIAction { [weak self] _ in
             self?.showSubmitMusicLoading()
         }, for: .touchUpInside)
@@ -84,13 +84,12 @@ class SelectMusicViewController: UIViewController {
     
     private func submitMusic() async throws {
         do {
-            self.selectCompleteButton.updateButton(.disabled)
+            selectCompleteButton.updateButton(.disabled)
             viewModel.stopMusic()
             progressBar.cancelCompletion()
             try await viewModel.submitMusic()
         } catch {
-            self.selectCompleteButton.updateButton(.complete)
-            throw ASAlertError.submitFailed
+            throw error
         }
     }
 }
@@ -98,17 +97,22 @@ class SelectMusicViewController: UIViewController {
 // MARK: - Alert
 
 extension SelectMusicViewController {
-    func showSubmitMusicLoading() {
-        let alert = ASAlertController(progressText: .submitMusic, load: { [weak self] in
-            try await self?.submitMusic()
-        }, errorCompletion: { [weak self] in
-            self?.showFailSubmitMusic()
-        })
+    private func showSubmitMusicLoading() {
+        let alert = ASAlertController(
+            progressText: .submitMusic,
+            load: { [weak self] in
+                try await self?.submitMusic()
+            },
+            errorCompletion: { [weak self] error in
+                self?.showFailSubmitMusic(error)
+            })
         presentLoadingView(alert)
     }
     
-    func showFailSubmitMusic() {
-        let alert = ASAlertController(errorType: .submitFailed)
+    private func showFailSubmitMusic(_ error: Error) {
+        let alert = ASAlertController(titleText: .error(error)) { [weak self] _ in
+            self?.selectCompleteButton.updateButton(.complete)
+        }
         presentAlert(alert)
     }
 }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SelectMusic/SelectMusicViewController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SelectMusic/SelectMusicViewController.swift
@@ -82,15 +82,15 @@ class SelectMusicViewController: UIViewController {
         }
     }
     
-    private func submitMusic() async {
+    private func submitMusic() async throws {
         do {
             selectCompleteButton.isEnabled = false
-            try await viewModel.submitMusic()
             viewModel.stopMusic()
             progressBar.cancelCompletion()
+            try await viewModel.submitMusic()
         } catch {
             selectCompleteButton.isEnabled = true
-            showFailSubmitMusic()
+            throw ASAlertError.submitFailed
         }
     }
 }
@@ -99,15 +99,16 @@ class SelectMusicViewController: UIViewController {
 
 extension SelectMusicViewController {
     func showSubmitMusicLoading() {
-        let alert = ASAlertController(progressText: .submitMusic) { [weak self] in
-            await self?.submitMusic()
-        }
+        let alert = ASAlertController(progressText: .submitMusic, load: { [weak self] in
+            try await self?.submitMusic()
+        }, errorCompletion: { [weak self] in
+            self?.showFailSubmitMusic()
+        })
         presentLoadingView(alert)
     }
     
     func showFailSubmitMusic() {
-        let alert = ASAlertController(style: .confirm, titleText: .submitFailld)
-    
+        let alert = ASAlertController(errorType: .submitFailed)
         presentAlert(alert)
     }
 }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SelectMusic/SelectMusicViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SelectMusic/SelectMusicViewModel.swift
@@ -6,24 +6,21 @@ import Foundation
 
 final class SelectMusicViewModel: ObservableObject, @unchecked Sendable {
     @Published public private(set) var answers: [Answer] = []
-    @Published public private(set) var searchList: [ASSong] = []
+    @Published public private(set) var searchList: [Music] = []
     @Published public private(set) var dueTime: Date?
-    @Published public private(set) var selectedSong: ASSong = .init(id: "12345")
+    @Published public private(set) var selectedMusic: Music?
     @Published public private(set) var musicData: Data? {
-        didSet {
-            isPlaying = true
-        }
+        didSet { isPlaying = true }
     }
 
     @Published public var isPlaying: Bool = false {
-        didSet {
-            isPlaying ? playingMusic() : stopMusic()
-        }
+        didSet { isPlaying ? playingMusic() : stopMusic() }
     }
     
     private let musicRepository: MusicRepositoryProtocol
     private let answerRepository: AnswersRepositoryProtocol
     private let gameStatusRepository: GameStatusRepositoryProtocol
+    
     private let musicAPI = ASMusicAPI()
     private var cancellable = Set<AnyCancellable>()
     
@@ -57,64 +54,53 @@ final class SelectMusicViewModel: ObservableObject, @unchecked Sendable {
             .store(in: &cancellable)
     }
     
-    func downloadMusic(url: URL?) {
-        guard let url else { return }
-        musicRepository.getMusicData(url: url)
-            .receive(on: DispatchQueue.main)
-            .sink { completion in
-                switch completion {
-                case .finished:
-                    break
-                case .failure(let error):
-                    print(error.localizedDescription)
-                }
-            } receiveValue: { [weak self] data in
-                self?.musicData = data
-            }
-            .store(in: &cancellable)
-    }
-    
-    func playingMusic() {
+    public func playingMusic() {
         guard let data = musicData else { return }
         Task {
             await AudioHelper.shared.startPlaying(file: data)
         }
     }
     
-    func stopMusic() {
+    public func stopMusic() {
         Task {
             await AudioHelper.shared.stopPlaying()
         }
     }
     
-    func handleSelectedSong(song: ASSong) {
-        selectedSong = song
+    public func downloadArtwork(url: URL?) async -> Data? {
+        guard let url else { return nil }
+        return await musicRepository.getMusicData(url: url)
+    }
+    
+    @MainActor
+    public func handleSelectedSong(with music: Music) {
+        selectedMusic = music
         beginPlaying()
     }
     
-    func beginPlaying() {
-        downloadMusic(url: selectedSong.previewURL)
-    }
-    
-    func submitMusic() async throws {
-        let answer = ASEntity.Music(
-            title: selectedSong.title,
-            artist: selectedSong.artistName,
-            artworkUrl: selectedSong.artwork?.url(
-                width: 300,
-                height: 300
-            ),
-            previewUrl: selectedSong.previewURL,
-            artworkBackgroundColor: selectedSong.artwork?.backgroundColor?.toHex()
-        )
-        let _ = try await answerRepository.submitMusic(answer: answer)
+    public func submitMusic() async throws {
+        guard let selectedMusic else { return }
+        _ = try await answerRepository.submitMusic(answer: selectedMusic)
     }
  
     @MainActor
-    func searchMusic(text: String) {
+    public func searchMusic(text: String) {
         Task {
             if text.isEmpty { return }
             searchList = await musicAPI.search(for: text)
         }
+    }
+    
+    @MainActor
+    private func downloadMusic(url: URL) {
+        Task {
+            musicData = await musicRepository.getMusicData(url: url)
+        }
+    }
+    
+    @MainActor
+    private func beginPlaying() {
+        guard let url = selectedMusic?.previewUrl else { return }
+        downloadMusic(url: url)
     }
 }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SelectMusic/SelectMusicViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SelectMusic/SelectMusicViewModel.swift
@@ -107,7 +107,7 @@ final class SelectMusicViewModel: ObservableObject, @unchecked Sendable {
             previewUrl: selectedSong.previewURL,
             artworkBackgroundColor: selectedSong.artwork?.backgroundColor?.toHex()
         )
-        let response = try await answerRepository.submitMusic(answer: answer)
+        let _ = try await answerRepository.submitMusic(answer: answer)
     }
  
     @MainActor

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SelectMusic/SelectMusicViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SelectMusic/SelectMusicViewModel.swift
@@ -1,26 +1,21 @@
 import ASEntity
 import ASMusicKit
 import ASRepository
+import ASNetworkKit
 import Combine
 import Foundation
-import MusicKit
 
-final class SelectMusicViewModel: ObservableObject {
+final class SelectMusicViewModel: ObservableObject, @unchecked Sendable {
     @Published public private(set) var answers: [Answer] = []
     @Published public private(set) var searchList: [ASSong] = []
     @Published public private(set) var dueTime: Date?
-    @Published public private(set) var selectedSong: ASSong = .init(
-        id: "12345",
-        title: "선택된 곡 없음",
-        artistName: "아티스트",
-        artwork: nil,
-        previewURL: URL(string: "")
-    )
+    @Published public private(set) var selectedSong: ASSong = .init(id: "12345")
     @Published public private(set) var musicData: Data? {
         didSet {
             isPlaying = true
         }
     }
+
     @Published public var isPlaying: Bool = false {
         didSet {
             isPlaying ? playingMusic() : stopMusic()
@@ -102,8 +97,7 @@ final class SelectMusicViewModel: ObservableObject {
         downloadMusic(url: selectedSong.previewURL)
     }
     
-    @MainActor
-    func submitMusic() {
+    func submitMusic() async throws {
         let answer = ASEntity.Music(
             title: selectedSong.title,
             artist: selectedSong.artistName,
@@ -114,13 +108,7 @@ final class SelectMusicViewModel: ObservableObject {
             previewUrl: selectedSong.previewURL,
             artworkBackgroundColor: selectedSong.artwork?.backgroundColor?.toHex()
         )
-        Task {
-            do {
-                let response = try await answerRepository.submitMusic(answer: answer)
-            } catch {
-                print(error.localizedDescription)
-            }
-        }
+        throw ASNetworkErrors.responseError
     }
  
     @MainActor

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SelectMusic/SelectMusicViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SelectMusic/SelectMusicViewModel.swift
@@ -1,7 +1,6 @@
 import ASEntity
 import ASMusicKit
 import ASRepository
-import ASNetworkKit
 import Combine
 import Foundation
 
@@ -108,7 +107,7 @@ final class SelectMusicViewModel: ObservableObject, @unchecked Sendable {
             previewUrl: selectedSong.previewURL,
             artworkBackgroundColor: selectedSong.artwork?.backgroundColor?.toHex()
         )
-        throw ASNetworkErrors.responseError
+        let response = try await answerRepository.submitMusic(answer: answer)
     }
  
     @MainActor

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SelectMusic/SelectMusicViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SelectMusic/SelectMusicViewModel.swift
@@ -80,15 +80,22 @@ final class SelectMusicViewModel: ObservableObject, @unchecked Sendable {
     
     public func submitMusic() async throws {
         guard let selectedMusic else { return }
-        _ = try await answerRepository.submitMusic(answer: selectedMusic)
+        do {
+            _ = try await answerRepository.submitMusic(answer: selectedMusic)
+        } catch {
+            throw error
+        }
     }
  
     @MainActor
-    public func searchMusic(text: String) {
-        Task {
+    public func searchMusic(text: String) async throws {
+        do {
             if text.isEmpty { return }
-            searchList = await musicAPI.search(for: text)
+            searchList = try await musicAPI.search(for: text)
+        } catch {
+            throw error
         }
+            
     }
     
     @MainActor

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SubmitAnswer/SelectAnswerView.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SubmitAnswer/SelectAnswerView.swift
@@ -29,7 +29,9 @@ struct SelectAnswerView: View {
 
             ASSearchBar(text: $searchTerm, placeHolder: "노래를 선택하세요")
                 .onChange(of: searchTerm) { newValue in
-                    viewModel.searchMusic(text: newValue)
+                    Task {
+                        try await viewModel.searchMusic(text: newValue)
+                    }
                 }
             List(viewModel.searchList) { music in
                 Button {

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SubmitAnswer/SelectAnswerView.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SubmitAnswer/SelectAnswerView.swift
@@ -9,11 +9,9 @@ struct SelectAnswerView: View {
     var body: some View {
         VStack {
             HStack {
-                ASMusicItemCell(
-                    artwork: viewModel.selectedSong.artwork,
-                    title: viewModel.selectedSong.title,
-                    artist: viewModel.selectedSong.artistName
-                )
+                ASMusicItemCell(music: viewModel.selectedMusic, fetchArtwork: { url in
+                    await viewModel.downloadArtwork(url: url)
+                })
                 .padding(EdgeInsets(top: 4, leading: 32, bottom: 4, trailing: 12))
                 Spacer()
                 Button {
@@ -33,12 +31,14 @@ struct SelectAnswerView: View {
                 .onChange(of: searchTerm) { newValue in
                     viewModel.searchMusic(text: newValue)
                 }
-            List(viewModel.searchList) { song in
+            List(viewModel.searchList) { music in
                 Button {
-                    viewModel.handleSelectedSong(song: song)
+                    viewModel.handleSelectedMusic(with: music)
                 } label: {
-                    ASMusicItemCell(artwork: song.artwork, title: song.title, artist: song.artistName)
-                        .tint(.black)
+                    ASMusicItemCell(music: music, fetchArtwork: { url in
+                        await viewModel.downloadArtwork(url: url)
+                    })
+                    .tint(.black)
                 }
             }
             .listStyle(.plain)

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SubmitAnswer/SubmitAnswerViewController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SubmitAnswer/SubmitAnswerViewController.swift
@@ -30,6 +30,7 @@ final class SubmitAnswerViewController: UIViewController {
     override func viewDidLoad() {
         setupUI()
         setupLayout()
+        setAction()
         bindToComponents()
     }
 
@@ -43,35 +44,22 @@ final class SubmitAnswerViewController: UIViewController {
     private func setupUI() {
         guideLabel.setText("허밍을 듣고 정답을 맞춰보세요!")
         selectAnswerButton.setConfiguration(title: "정답 선택", backgroundColor: .asLightSky)
-        selectAnswerButton.addAction(UIAction { [weak self] _ in
-            guard let self else { return }
-            let selecAnswerView = UIHostingController(rootView: SelectAnswerView(viewModel: viewModel))
-            present(selecAnswerView, animated: true)
-        },
-        for: .touchUpInside)
         submitButton.setConfiguration(title: "정답 제출", backgroundColor: .asLightGray)
-        submitButton.addAction(
-            UIAction { [weak self] _ in
-                self?.showSubmitLoading()
-            }, for: .touchUpInside
-        )
-        progressBar.setCompletionHandler { [weak self] in
-            self?.showSubmitLoading()
-        }
         submitButton.updateButton(.disabled)
         buttonStack.axis = .horizontal
         buttonStack.spacing = 16
         buttonStack.addArrangedSubview(selectAnswerButton)
         buttonStack.addArrangedSubview(submitButton)
         view.backgroundColor = .asLightGray
+    }
+
+    private func setupLayout() {
         view.addSubview(progressBar)
         view.addSubview(guideLabel)
         view.addSubview(musicPanel)
         view.addSubview(buttonStack)
         view.addSubview(submissionStatus)
-    }
 
-    private func setupLayout() {
         progressBar.translatesAutoresizingMaskIntoConstraints = false
         guideLabel.translatesAutoresizingMaskIntoConstraints = false
         musicPanel.translatesAutoresizingMaskIntoConstraints = false
@@ -101,29 +89,53 @@ final class SubmitAnswerViewController: UIViewController {
         ])
     }
 
-    func submitAnswer() async throws {
+    private func submitAnswer() async throws {
         do {
             selectAnswerButton.updateButton(.disabled)
             viewModel.stopMusic()
             progressBar.cancelCompletion()
             try await viewModel.submitAnswer()
         } catch {
-            selectAnswerButton.updateButton(.complete)
-            throw ASAlertError.submitFailed
+            throw error
         }
     }
 
-    func showSubmitLoading() {
+    private func setAction() {
+        selectAnswerButton.addAction(UIAction { [weak self] _ in
+            guard let self else { return }
+            let selecAnswerView = UIHostingController(rootView: SelectAnswerView(viewModel: viewModel))
+            present(selecAnswerView, animated: true)
+        },
+        for: .touchUpInside)
+
+        submitButton.addAction(
+            UIAction { [weak self] _ in
+                self?.showSubmitAnswerLoading()
+            }, for: .touchUpInside
+        )
+
+        progressBar.setCompletionHandler { [weak self] in
+            self?.showSubmitAnswerLoading()
+        }
+    }
+}
+
+// MARK: - Alert
+
+extension SubmitAnswerViewController {
+    private func showSubmitAnswerLoading() {
         let alert = ASAlertController(progressText: .submitMusic, load: { [weak self] in
             try await self?.submitAnswer()
-        }, errorCompletion: { [weak self] in
-            self?.showSubmitFailed()
-        })
+        }) { [weak self] error in
+            self?.showFailSubmitMusic(error)
+        }
         presentLoadingView(alert)
     }
 
-    func showSubmitFailed() {
-        let alert = ASAlertController(errorType: .submitFailed)
+    private func showFailSubmitMusic(_ error: Error) {
+        let alert = ASAlertController(titleText: .error(error)) { [weak self] _ in
+            self?.selectAnswerButton.updateButton(.complete)
+        }
         presentAlert(alert)
     }
 }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SubmitAnswer/SubmitAnswerViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SubmitAnswer/SubmitAnswerViewModel.swift
@@ -103,7 +103,7 @@ final class SubmitAnswerViewModel: ObservableObject, @unchecked Sendable {
         downloadMusic(url: selectedSong.previewURL)
     }
 
-    func submitAnswer() async {
+    func submitAnswer() async throws {
         guard let artworkBackgroundColor = selectedSong.artwork?.backgroundColor?.toHex() else { return }
         let answer = ASEntity.Music(
             title: selectedSong.title,
@@ -115,7 +115,7 @@ final class SubmitAnswerViewModel: ObservableObject, @unchecked Sendable {
         do {
             let response = try await submitsRepository.submitAnswer(answer: answer)
         } catch {
-            print(error.localizedDescription)
+            throw error
         }
     }
 

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SubmitAnswer/SubmitAnswerViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SubmitAnswer/SubmitAnswerViewModel.swift
@@ -46,7 +46,6 @@ final class SubmitAnswerViewModel: ObservableObject, @unchecked Sendable {
         self.musicRepository = musicRepository
         bindGameStatus()
         bindSubmitStatus()
-        print("did load", pthread_self())
     }
 
     private func bindRecord(on recordOrder: UInt8) {

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SubmitAnswer/SubmitAnswerViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SubmitAnswer/SubmitAnswerViewModel.swift
@@ -6,47 +6,31 @@ import Foundation
 import MusicKit
 
 final class SubmitAnswerViewModel: ObservableObject, @unchecked Sendable {
-    private var cancellable = Set<AnyCancellable>()
+    @Published public private(set) var searchList: [Music] = []
+    @Published public private(set) var selectedMusic: Music?
+    @Published public private(set) var dueTime: Date?
+    @Published public private(set) var recordOrder: UInt8?
+    @Published public private(set) var status: Status?
+    @Published public private(set) var submissionStatus: (submits: String, total: String) = ("0", "0")
+    @Published public private(set) var music: Music?
+    @Published public private(set) var recordedData: Data?
+    @Published public private(set) var isRecording: Bool = false
+    @Published public private(set) var musicData: Data? {
+        didSet { isPlaying = true }
+    }
+
+    @Published public private(set) var isPlaying: Bool = false {
+        didSet { isPlaying ? playingMusic() : stopMusic() }
+    }
+
     private let musicRepository: MusicRepositoryProtocol
     private let gameStatusRepository: GameStatusRepositoryProtocol
     private let playersRepository: PlayersRepositoryProtocol
     private let recordsRepository: RecordsRepositoryProtocol
     private let submitsRepository: SubmitsRepositoryProtocol
+
+    private let musicAPI = ASMusicAPI()
     private var cancellables: Set<AnyCancellable> = []
-
-    let musicAPI = ASMusicAPI()
-
-    @Published var musicData: Data? {
-        didSet {
-            isPlaying = true
-        }
-    }
-
-    @Published var searchList: [ASSong] = []
-    @Published var selectedSong: ASSong = .init(
-        id: "12345",
-        title: "선택된 곡 없음",
-        artistName: "아티스트",
-        artwork: nil,
-        previewURL: URL(string: "")
-    )
-    @Published var isPlaying: Bool = false {
-        didSet {
-            if isPlaying {
-                playingMusic()
-            } else {
-                stopMusic()
-            }
-        }
-    }
-
-    @Published private(set) var dueTime: Date?
-    @Published private(set) var recordOrder: UInt8?
-    @Published private(set) var status: Status?
-    @Published private(set) var submissionStatus: (submits: String, total: String) = ("0", "0")
-    @Published private(set) var music: Music?
-    @Published private(set) var recordedData: Data?
-    @Published private(set) var isRecording: Bool = false
 
     init(
         gameStatusRepository: GameStatusRepositoryProtocol,
@@ -62,88 +46,6 @@ final class SubmitAnswerViewModel: ObservableObject, @unchecked Sendable {
         self.musicRepository = musicRepository
         bindGameStatus()
         bindSubmitStatus()
-    }
-
-    func downloadMusic(url: URL?) {
-        guard let url else { return }
-        musicRepository.getMusicData(url: url)
-            .receive(on: DispatchQueue.main)
-            .sink { completion in
-                switch completion {
-                case .finished:
-                    break
-                case .failure(let error):
-                    print(error.localizedDescription)
-                }
-            } receiveValue: { [weak self] data in
-                self?.musicData = data
-            }
-            .store(in: &cancellable)
-    }
-
-    func playingMusic() {
-        guard let data = musicData else { return }
-        Task {
-            await AudioHelper.shared.startPlaying(file: data)
-        }
-    }
-
-    func stopMusic() {
-        Task {
-            await AudioHelper.shared.stopPlaying()
-        }
-    }
-
-    func handleSelectedSong(song: ASSong) {
-        selectedSong = song
-        beginPlaying()
-    }
-
-    func beginPlaying() {
-        downloadMusic(url: selectedSong.previewURL)
-    }
-
-    func submitAnswer() async throws {
-        guard let artworkBackgroundColor = selectedSong.artwork?.backgroundColor?.toHex() else { return }
-        let answer = ASEntity.Music(
-            title: selectedSong.title,
-            artist: selectedSong.artistName,
-            artworkUrl: selectedSong.artwork?.url(width: 300, height: 300),
-            previewUrl: selectedSong.previewURL,
-            artworkBackgroundColor: artworkBackgroundColor
-        )
-        do {
-            let response = try await submitsRepository.submitAnswer(answer: answer)
-        } catch {
-            throw error
-        }
-    }
-
-    @MainActor
-    func searchMusic(text: String) {
-        Task {
-            searchList = await musicAPI.search(for: text)
-        }
-    }
-
-    // MARK: - 이부분 부터 RehummingViewModel
-
-    func startRecording() {
-        isRecording = true
-    }
-
-    @MainActor
-    func togglePlayPause() {
-        Task {
-            await AudioHelper.shared.startPlaying(file: recordedData)
-        }
-    }
-
-    func updateRecordedData(with data: Data) {
-        // TODO: - data가 empty일 때(녹음이 제대로 되지 않았을 때 사용자 오류처리 필요
-        guard !data.isEmpty else { return }
-        recordedData = data
-        isRecording = false
     }
 
     private func bindRecord(on recordOrder: UInt8) {
@@ -184,5 +86,78 @@ final class SubmitAnswerViewModel: ObservableObject, @unchecked Sendable {
                 self?.submissionStatus = submitStatus
             }
             .store(in: &cancellables)
+    }
+    
+    public func playingMusic() {
+        guard let data = musicData else { return }
+        Task {
+            await AudioHelper.shared.startPlaying(file: data)
+        }
+    }
+
+    public func stopMusic() {
+        Task {
+            await AudioHelper.shared.stopPlaying()
+        }
+    }
+
+    public func downloadArtwork(url: URL?) async -> Data? {
+        guard let url else { return nil }
+        return await musicRepository.getMusicData(url: url)
+    }
+
+    @MainActor
+    public func downloadMusic(url: URL) {
+        Task {
+            musicData = await musicRepository.getMusicData(url: url)
+        }
+    }
+
+    @MainActor
+    public func searchMusic(text: String) {
+        Task {
+            if text.isEmpty { return }
+            searchList = await musicAPI.search(for: text)
+        }
+    }
+
+    @MainActor
+    public func handleSelectedMusic(with music: Music) {
+        selectedMusic = music
+        beginPlaying()
+    }
+
+    @MainActor
+    private func beginPlaying() {
+        guard let previewUrl = selectedMusic?.previewUrl else { return }
+        downloadMusic(url: previewUrl)
+    }
+
+    public func submitAnswer() async throws {
+        guard let selectedMusic else { return }
+        do {
+            let response = try await submitsRepository.submitAnswer(answer: selectedMusic)
+        } catch {
+            throw error
+        }
+    }
+
+    // MARK: - 이부분 부터 RehummingViewModel
+
+    public func startRecording() {
+        isRecording = true
+    }
+
+    public func togglePlayPause() {
+        Task {
+            await AudioHelper.shared.startPlaying(file: recordedData)
+        }
+    }
+
+    public func updateRecordedData(with data: Data) {
+        // TODO: - data가 empty일 때(녹음이 제대로 되지 않았을 때 사용자 오류처리 필요
+        guard !data.isEmpty else { return }
+        recordedData = data
+        isRecording = false
     }
 }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SubmitAnswer/SubmitAnswerViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SubmitAnswer/SubmitAnswerViewModel.swift
@@ -114,10 +114,12 @@ final class SubmitAnswerViewModel: ObservableObject, @unchecked Sendable {
     }
 
     @MainActor
-    public func searchMusic(text: String) {
-        Task {
+    public func searchMusic(text: String) async throws {
+        do {
             if text.isEmpty { return }
-            searchList = await musicAPI.search(for: text)
+            searchList = try await musicAPI.search(for: text)
+        } catch {
+            throw error
         }
     }
 

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SubmitAnswer/SubmitAnswerViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SubmitAnswer/SubmitAnswerViewModel.swift
@@ -5,7 +5,7 @@ import Combine
 import Foundation
 import MusicKit
 
-final class SubmitAnswerViewModel: ObservableObject {
+final class SubmitAnswerViewModel: ObservableObject, @unchecked Sendable {
     private var cancellable = Set<AnyCancellable>()
     private let musicRepository: MusicRepositoryProtocol
     private let gameStatusRepository: GameStatusRepositoryProtocol

--- a/firebase/functions/api/SubmitAnswer.js
+++ b/firebase/functions/api/SubmitAnswer.js
@@ -24,9 +24,9 @@ module.exports.submitAnswer = onRequest({ region: 'asia-southeast1' }, async (re
   }
   try {
     const roomRef = admin.firestore().collection('rooms').doc(roomNumber);
-    const userData = roomData.players.find((player) => player.id === userId);
     const roomSnapshot = await roomRef.get();
     const roomData = roomSnapshot.data();
+    const userData = roomData.players.find((player) => player.id === userId);
     const playersCount = roomData.players.length;
     const submitCount = roomData.submits.length;
     if (!userData) {

--- a/firebase/functions/api/SubmitAnswer.js
+++ b/firebase/functions/api/SubmitAnswer.js
@@ -25,6 +25,11 @@ module.exports.submitAnswer = onRequest({ region: 'asia-southeast1' }, async (re
   try {
     const playerData = await getUserData(userId);
     const roomRef = admin.firestore().collection('rooms').doc(roomNumber);
+    const userData = await getUserData(userId);
+    const roomSnapshot = await roomRef.get();
+    const roomData = roomSnapshot.data();
+    const playersCount = roomData.players.length;
+    const submitCount = roomData.submits.length;
     if (!playerData) {
       return res.status(404).json({ error: 'plyer Data not found' });
     }
@@ -32,9 +37,17 @@ module.exports.submitAnswer = onRequest({ region: 'asia-southeast1' }, async (re
       player: playerData,
       music: req.body,
     };
-    await roomRef.update({
-      submits: FieldValue.arrayUnion(answer),
-    });
+    if (submitCount - 1 === playersCount) {
+      await roomRef.update({
+        submits: FieldValue.arrayUnion(answer),
+        status: 'result',
+      });
+    } else {
+      await roomRef.update({
+        submits: FieldValue.arrayUnion(answer),
+      });
+    }
+
     res.status(200).json({ status: 'success' });
   } catch (error) {
     console.log('에러러', error);

--- a/firebase/functions/api/SubmitAnswer.js
+++ b/firebase/functions/api/SubmitAnswer.js
@@ -23,18 +23,17 @@ module.exports.submitAnswer = onRequest({ region: 'asia-southeast1' }, async (re
     return res.status(400).json({ error: 'Room Number is required' });
   }
   try {
-    const playerData = await getUserData(userId);
     const roomRef = admin.firestore().collection('rooms').doc(roomNumber);
-    const userData = await getUserData(userId);
+    const userData = roomData.players.find((player) => player.id === userId);
     const roomSnapshot = await roomRef.get();
     const roomData = roomSnapshot.data();
     const playersCount = roomData.players.length;
     const submitCount = roomData.submits.length;
-    if (!playerData) {
+    if (!userData) {
       return res.status(404).json({ error: 'plyer Data not found' });
     }
     const answer = {
-      player: playerData,
+      player: userData,
       music: req.body,
     };
     if (submitCount + 1 === playersCount) {

--- a/firebase/functions/api/SubmitAnswer.js
+++ b/firebase/functions/api/SubmitAnswer.js
@@ -37,7 +37,7 @@ module.exports.submitAnswer = onRequest({ region: 'asia-southeast1' }, async (re
       player: playerData,
       music: req.body,
     };
-    if (submitCount - 1 === playersCount) {
+    if (submitCount + 1 === playersCount) {
       await roomRef.update({
         submits: FieldValue.arrayUnion(answer),
         status: 'result',

--- a/firebase/functions/api/SubmitMusic.js
+++ b/firebase/functions/api/SubmitMusic.js
@@ -23,14 +23,13 @@ module.exports.submitMusic = onRequest({ region: 'asia-southeast1' }, async (req
     return res.status(400).json({ error: 'Room Number is required' });
   }
   try {
-    const playerData = await getUserData(userId);
     const roomRef = admin.firestore().collection('rooms').doc(roomNumber);
     const roomSnapshot = await roomRef.get();
     const roomData = roomSnapshot.data();
-
+    const userData = roomData.players.find((player) => player.id === userId);
     const currentAnswer = roomData.answers.length;
     const playersCount = roomData.players.length;
-    if (!playerData) {
+    if (!userData) {
       return res.status(404).json({ error: 'plyer Data not found' });
     }
     const currentMode = roomData.mode;
@@ -41,7 +40,7 @@ module.exports.submitMusic = onRequest({ region: 'asia-southeast1' }, async (req
 
         if (!req.body) {
           const answer = {
-            player: playerData,
+            player: userData,
           };
           await roomRef.update({
             round: 1,
@@ -52,7 +51,7 @@ module.exports.submitMusic = onRequest({ region: 'asia-southeast1' }, async (req
         }
 
         const answer = {
-          player: playerData,
+          player: userData,
           music: req.body,
         };
         // 모든 사람이 제출했을 때

--- a/firebase/functions/api/UploadRecord.js
+++ b/firebase/functions/api/UploadRecord.js
@@ -128,7 +128,7 @@ app.post('/uploadrecording', async (req, res) => {
             console.log('Invalid mode');
             break;
         }
-        res.status(200).send({ success: true, url: publicUrl });
+        res.status(200).send({ success: true });
       } catch (error) {
         console.error('Error after file upload:', error);
         return res.status(500).json({ error: 'Failed to process file' });

--- a/firebase/functions/api/UploadRecord.js
+++ b/firebase/functions/api/UploadRecord.js
@@ -82,8 +82,8 @@ app.post('/uploadrecording', async (req, res) => {
         if (!playerExists) {
           return res.status(400).json({ error: 'User not in the room' });
         }
+        const userData = roomData.players.find((player) => player.id === userId);
 
-        const userData = await getUserData(userId);
         if (!userData) {
           return res.status(404).json({ error: 'User not found' });
         }

--- a/firebase/functions/api/UploadRecord.js
+++ b/firebase/functions/api/UploadRecord.js
@@ -116,13 +116,19 @@ app.post('/uploadrecording', async (req, res) => {
               recordOrder: roomData.recordOrder,
               fileUrl: publicUrl,
             };
-
-            await roomRef.update({
-              recordOrder: currentOrderRecord + 1,
-              status: 'rehumming',
-              dueTime: dueTime,
-              records: FieldValue.arrayUnion(record),
-            });
+            if (currentRoundRecords.length + 1 === playersCount) {
+              await roomRef.update({
+                recordOrder: currentOrderRecord + 1,
+                status: 'rehumming',
+                dueTime: dueTime,
+                records: FieldValue.arrayUnion(record),
+              });
+            } else {
+              await roomRef.update({
+                status: 'rehumming',
+                records: FieldValue.arrayUnion(record),
+              });
+            }
             break;
           default:
             console.log('Invalid mode');

--- a/firebase/functions/index.js
+++ b/firebase/functions/index.js
@@ -10,7 +10,8 @@ const { onRemovePlayer, onRemoveRoom } = require('./trigger/onRemovePlayer.js');
 const { changeMode } = require('./api/ChangeMode.js');
 const { submitMusic } = require('./api/SubmitMusic');
 const { submitAnswer } = require('./api/SubmitAnswer');
-const { changeRecordOrder } = require('./api/ChangeRecordOrder.js')
+const { changeRecordOrder } = require('./api/ChangeRecordOrder.js');
+const { resetGame } = require('./api/ResetGame.js');
 
 // 방 관련 API
 exports.createRoom = createRoom;
@@ -22,6 +23,7 @@ exports.onRemoveRoom = onRemoveRoom;
 exports.submitMusic = submitMusic;
 exports.submitAnswer = submitAnswer;
 exports.changeRecordOrder = changeRecordOrder;
+exports.resetGame = resetGame;
 
 // GameStart API
 exports.startGame = startGame;


### PR DESCRIPTION
## What is this PR?
- Status와 Round에 따른 화면 전환을 추가하였습니다.
- 비동기 함수를 호출중임을 표시하기 위한 로딩 Alert를 추가하였습니다. 


추가된 작업
- Music 과 Answer을 제출하는 뷰모델에서 사용하는 ASsong을 제거하였습니다. 
- Alert 에서 Error를 처리하는 로직을 추가하였습니다.
* 서치하는 작업, 다운로드 받는 작업은 비동기로 처리,
* 업데이트하는 로직만 메인 엑터로 분리

## PR Type
- [x] Bugfix
- [ ] Chore
- [x] New feature (기능을 추가하는 feat)
- [ ] Breaking change (기존의 기능이 동작하지 않을 수 있는 fix/feat)
- [ ] Documentation Update

## ScreenShot(if available)
|기능|스크린샷|
|:--:|:--:|
|에러처리|<img src = "https://github.com/user-attachments/assets/01160db2-feb6-4ea3-8a72-62ba1b7fbbe8" width ="250">|

## Further comments
- 확인된 이슈 : 4인일 때 기준으로는 정상적으로 허밍과 리허밍의 횟수가 일치하나 3인 이하부터는 조금 문제가 있습니다.
  - 다음 브렌치에서 해결하도록 하겠습니다.

### 타이머 제대로 동작하지 않는 문제 임시 해결
```swift
    private func startProgressAnimation() {
        guard let targetDate else { return }
        let timeInterval = targetDate.timeIntervalSince(Date.now)
        if timeInterval < 50 { return } // 임시로 50으로 잡아 준 이유
```
뷰와 뷰로 넘어가는 과정에서 이전 뷰의 dueDate가 남아있고, 뷰 이동 시 나아있는 due Date를 sink하고 있어 다음 타이머가 빨리 흘러가는 문제를 발견하였습니다. 
startProgressAnimation이 시작되면 stream을 끊어내려고 하였으나 다음 뷰로 넘어갈때 dueDate가 0으로 고정되는 이슈가 생겼었습니다.
우선 다음 뷰로 넘어갈 때 정상적인 값을 초기화를 위해서 고정값으로 50s를 주었고,  다른 방법을 찾아서 해결 해보도록 하겠습니다.

### SwiftUI 에러 뷰가 존재하지 않는 문제
SwiftUI 에서 Alert를 띄울 방도가 없어서 남겨놓았습니다. 

### 에러가 났을 경우 button을 .complete 상태로 변경하였는데, 원상복구 시키는 버튼 상태를 추가해야할 것 같아요


