### PR TITLE
feat: 두 명 이상 들어와야 시작 가능 하도록 변경 

### DIFF
--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/ASAlertController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/ASAlertController.swift
@@ -320,6 +320,7 @@ enum ASAlertText {
         case joinRoom
         case joinFailed
         case error(Error)
+        case needMorePlayer
 
         var description: String {
             switch self {
@@ -327,6 +328,7 @@ enum ASAlertText {
                 case .joinRoom: "게임 입장 코드를 입력하세요"
                 case .joinFailed: "참가에 실패하였습니다."
                 case .error(let error): "\(error.localizedDescription)\n 잠시후에 다시 시도해주세요"
+                case .needMorePlayer: "알쏭달쏭은 여럿이서 할 수록\n재미있는 게임이에요!\n그래도 하시겠어요?"
             }
         }
     }
@@ -336,6 +338,7 @@ enum ASAlertText {
         case cancel
         case done
         case confirm
+        case keep
 
         var description: String {
             switch self {
@@ -343,6 +346,7 @@ enum ASAlertText {
                 case .cancel: "취소"
                 case .done: "완료"
                 case .confirm: "확인"
+                case .keep: "계속 하기"
             }
         }
     }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/ASButton.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/ASButton.swift
@@ -94,6 +94,7 @@ final class ASButton: UIButton {
             case .submitted:
                 setConfiguration(title: "제출 완료")
                 disable()
+            case .startGame: setConfiguration(systemImageName: "play.fill", title: "시작하기!", backgroundColor: .asMint)
         }
     }
 
@@ -106,6 +107,7 @@ final class ASButton: UIButton {
         case complete
         case submit
         case submitted
+        case startGame
     }
 }
 

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Lobby/LobbyViewController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Lobby/LobbyViewController.swift
@@ -62,6 +62,18 @@ final class LobbyViewController: UIViewController {
                 self?.startButton.isEnabled = isHost
             }
             .store(in: &cancellables)
+        
+        viewmodel.$canBeginGame
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] canBeginGame in
+                if !canBeginGame {
+                    self?.startButton.updateButton(.disabled)
+                } else {
+                    self?.startButton.updateButton(.startGame)
+                    self?.startButton.isEnabled = true
+                }
+            }
+            .store(in: &cancellables)
     }
     
     private func setupUI() {
@@ -96,10 +108,11 @@ final class LobbyViewController: UIViewController {
                 let leaveAlert = ASAlertController(
                     titleText: .leaveRoom,
                     doneButtonTitle: .leave,
-                    cancelButtonTitle: .cancel) { [weak self] _ in
-                        self?.viewmodel.leaveRoom()
-                        self?.navigationController?.popViewController(animated: true)
-                    }
+                    cancelButtonTitle: .cancel)
+                { [weak self] _ in
+                    self?.viewmodel.leaveRoom()
+                    self?.navigationController?.popViewController(animated: true)
+                }
                 self?.present(leaveAlert, animated: true, completion: nil)
             },
             for: .touchUpInside)
@@ -163,9 +176,9 @@ final class LobbyViewController: UIViewController {
         ])
     }
     
-    private func gameStart() async throws{
+    private func gameStart() async throws {
         do {
-            try await self.viewmodel.gameStart()
+            try await viewmodel.gameStart()
         } catch {
             throw error
         }
@@ -182,8 +195,8 @@ extension LobbyViewController {
                 try await self?.gameStart()
             },
             errorCompletion: { [weak self] error in
-            self?.showStartGameFailed(error)
-        })
+                self?.showStartGameFailed(error)
+            })
         presentLoadingView(alert)
     }
     

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Lobby/LobbyViewController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Lobby/LobbyViewController.swift
@@ -126,9 +126,24 @@ final class LobbyViewController: UIViewController {
             }
         }, for: .touchUpInside)
         
-        startButton.addAction(UIAction { [weak self] _ in
-            self?.showStartGameLoading()
-        }, for: .touchUpInside)
+        startButton.addAction(
+            UIAction { [weak self] _ in
+                guard let playerCount = self?.viewmodel.players.count else { return }
+                if playerCount < 3 {
+                    let nojamAlert = ASAlertController(
+                        style: .default,
+                        titleText: .needMorePlayer,
+                        doneButtonTitle: .keep,
+                        cancelButtonTitle: .cancel)
+                    { _ in
+                        self?.showStartGameLoading()
+                    }
+                    self?.present(nojamAlert, animated: true, completion: nil)
+                } else {
+                    self?.showStartGameLoading()
+                }
+            },
+            for: .touchUpInside)
     }
     
     private func setupLayout() {


### PR DESCRIPTION
## What is this PR?
- PR에 대한 설명
LobbyViewModel에서 isHost, playerCount 를 combineLatest 하였습니다. 현재 조건에 따라 게임을 시작 가능한지 나타내는 bool 변수인 
canBeginGame을 만들었고 이를 LobbyViewController에 combine 해두어 버튼의 상태가 동적으로 변하도록 하였습니다.

```swift
playersRepository.isHost().combineLatest(playersRepository.getPlayersCount())
            .receive(on: DispatchQueue.main)
            .sink { [weak self] isHost, playerCount in
                self?.canBeginGame = isHost && playerCount > 1
                print("현재 canBeginGame: \(self?.canBeginGame)")
            }
            .store(in: &cancellables)
```
## Screenshot
*Simulator에 아바타 사진 안뜨는 오류 있습니다. 참고바랍니다. 실기기에서는 잘 됩니다!*

https://github.com/user-attachments/assets/e4e5b7f3-9bb4-465d-8e7b-becb560d2811



## PR Type
- [ ] Bugfix
- [ ] Chore
- [x] New feature (기능을 추가하는 feat)
- [ ] Breaking change (기존의 기능이 동작하지 않을 수 있는 fix/feat)
- [ ] Documentation Update