### PR TITLE
fix: 제출 현황 제대로 안 보이는 문제 해결

### DIFF
--- a/alsongDalsong/ASRepository/ASRepository/Protocols/RepositoryProtocols.swift
+++ b/alsongDalsong/ASRepository/ASRepository/Protocols/RepositoryProtocols.swift
@@ -24,7 +24,7 @@ public protocol PlayersRepositoryProtocol {
 
 public protocol RecordsRepositoryProtocol {
     func getRecords() -> AnyPublisher<[ASEntity.Record], Never>
-    func getRecordsCount(on recordOrder: Int) -> AnyPublisher<Int, Never>
+    func getRecordsCount(on recordOrder: UInt8) -> AnyPublisher<Int, Never>
     func getHumming(on recordOrder: UInt8) -> AnyPublisher<ASEntity.Record?, Never>
     func uploadRecording(_ record: Data) async throws -> Bool
 }
@@ -41,6 +41,7 @@ public protocol SelectedRecordsRepositoryProtocol {
 
 public protocol SubmitsRepositoryProtocol {
     func getSubmits() -> AnyPublisher<[Answer], Never>
+    func getSubmitsCount() -> AnyPublisher<Int, Never>
     func submitAnswer(answer: Music) async throws -> Bool
 }
 

--- a/alsongDalsong/ASRepository/ASRepository/Repositories/RecordsRepository.swift
+++ b/alsongDalsong/ASRepository/ASRepository/Repositories/RecordsRepository.swift
@@ -16,13 +16,15 @@ public final class RecordsRepository: RecordsRepositoryProtocol {
             .eraseToAnyPublisher()
     }
 
-    public func getRecordsCount(on recordOrder: Int) -> AnyPublisher<Int, Never> {
-        mainRepository.records
+    public func getRecordsCount(on recordOrder: UInt8) -> AnyPublisher<Int, Never> {
+       return mainRepository.records
             .compactMap { $0 }
             .map { records in
-                records.filter { Int($0.recordOrder ?? 0) == recordOrder }
+                return records.filter { Int($0.recordOrder ?? 0) == recordOrder }
             }
-            .map { $0.count }
+            .map {
+                return $0.count
+            }
             .eraseToAnyPublisher()
     }
 

--- a/alsongDalsong/ASRepository/ASRepository/Repositories/SubmitsRepository.swift
+++ b/alsongDalsong/ASRepository/ASRepository/Repositories/SubmitsRepository.swift
@@ -20,7 +20,15 @@ public final class SubmitsRepository: SubmitsRepositoryProtocol {
             .compactMap { $0 }
             .eraseToAnyPublisher()
     }
-
+    
+    public func getSubmitsCount() -> AnyPublisher<Int, Never> {
+        mainRepository.submits
+            .receive(on: DispatchQueue.main)
+            .compactMap { $0 }
+            .map { $0.count }
+            .eraseToAnyPublisher()
+    }
+    
     public func submitAnswer(answer: Music) async throws -> Bool {
         let queryItems = [URLQueryItem(name: "userId", value: ASFirebaseAuth.myID),
                           URLQueryItem(name: "roomNumber", value: mainRepository.number.value)]

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Humming/HummingViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Humming/HummingViewModel.swift
@@ -29,7 +29,6 @@ final class HummingViewModel: @unchecked Sendable {
         self.answersRepository = answersRepository
         self.recordsRepository = recordsRepository
         bindGameStatus()
-        bindSubmitStatus()
         bindAnswer()
     }
 
@@ -76,6 +75,7 @@ final class HummingViewModel: @unchecked Sendable {
         gameStatusRepository.getRecordOrder()
             .sink { [weak self] newRecordOrder in
                 self?.recordOrder = newRecordOrder
+                self?.bindSubmissionStatus(with: newRecordOrder)
             }
             .store(in: &cancellables)
         gameStatusRepository.getStatus()
@@ -85,9 +85,9 @@ final class HummingViewModel: @unchecked Sendable {
             .store(in: &cancellables)
     }
 
-    private func bindSubmitStatus() {
+    private func bindSubmissionStatus(with recordOrder: UInt8) {
         let playerPublisher = playersRepository.getPlayersCount()
-        let recordsPublisher = recordsRepository.getRecordsCount(on: Int(recordOrder ?? 0))
+        let recordsPublisher = recordsRepository.getRecordsCount(on: recordOrder)
 
         playerPublisher.combineLatest(recordsPublisher)
             .receive(on: DispatchQueue.main)

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Rehumming/RehummingViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Rehumming/RehummingViewModel.swift
@@ -26,7 +26,6 @@ final class RehummingViewModel: @unchecked Sendable {
         self.playersRepository = playersRepository
         self.recordsRepository = recordsRepository
         bindGameStatus()
-        bindSubmitStatus()
     }
 
     func submitHumming() async throws {
@@ -73,6 +72,7 @@ final class RehummingViewModel: @unchecked Sendable {
             .sink { [weak self] newRecordOrder in
                 self?.recordOrder = newRecordOrder
                 self?.bindRecord(on: newRecordOrder)
+                self?.bindSubmissionStatus(with: newRecordOrder)
             }
             .store(in: &cancellables)
         gameStatusRepository.getStatus()
@@ -82,9 +82,9 @@ final class RehummingViewModel: @unchecked Sendable {
             .store(in: &cancellables)
     }
 
-    private func bindSubmitStatus() {
+    private func bindSubmissionStatus(with recordOrder: UInt8) {
         let playerPublisher = playersRepository.getPlayersCount()
-        let recordsPublisher = recordsRepository.getRecordsCount(on: Int(recordOrder ?? 0))
+        let recordsPublisher = recordsRepository.getRecordsCount(on: recordOrder)
 
         playerPublisher.combineLatest(recordsPublisher)
             .sink { [weak self] playersCount, recordsCount in


### PR DESCRIPTION
## What is this PR?
- 리허밍, 음악 선택 뷰에서 제출 현황이 제대로 보이지 않는 문제를 해결했습니다.

## PR Type
- [x] Bugfix
- [ ] Chore
- [ ] New feature (기능을 추가하는 feat)
- [ ] Breaking change (기존의 기능이 동작하지 않을 수 있는 fix/feat)
- [ ] Documentation Update

## Further comments
이유는,, 제출현황 bind가 단 한번 되는데 roundRecord가 필요합니다. 근데 roundRecord가 없는 상태에서 호출하니 바인딩이 제대로 될 리가 없... 
bindRoundRecord 함수 내에서 제출현황을 바인딩하는 함수를 호출하도록 변경하였습니다.