### PR TITLE
fix: 동시 제출 화면 전환이 안되는 이슈 해결

### DIFF
--- a/alsongDalsong/ASNetworkKit/ASNetworkKit/FirebaseEndpoint.swift
+++ b/alsongDalsong/ASNetworkKit/ASNetworkKit/FirebaseEndpoint.swift
@@ -42,11 +42,11 @@ public struct FirebaseEndpoint: Endpoint, Equatable {
                 case .changeMode:
                     "/changeMode"
                 case .uploadRecording:
-                    "/uploadRecording"
+                    "/v2-uploadRecording"
                 case .submitMusic:
-                    "/submitMusic"
+                    "/v2-submitMusic"
                 case .submitAnswer:
-                    "/submitAnswer"
+                    "/v2-submitAnswer"
                 case .changeRecordOrder:
                     "/changeRecordOrder"
             }

--- a/firebase/functions/api/SubmitAnswerV2.js
+++ b/firebase/functions/api/SubmitAnswerV2.js
@@ -1,0 +1,81 @@
+// TODO : 정답 제출 API입니다.
+// fireStore database의 rooms/{roomNumber} 에 room 데이터를 생성합니다.
+const { FieldValue } = require('firebase-admin/firestore');
+const { onRequest } = require('firebase-functions/v2/https');
+const admin = require('../FirebaseAdmin.js');
+
+/**
+ * 정답 제출을 처리하는 API
+ * @param userId - 사용자 ID
+ * @param roomNumber - 방 번호
+ * @returns 상태 메시지
+ */
+module.exports.submitAnswerV2 = onRequest({ region: 'asia-southeast1' }, async (req, res) => {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Only POST requests are accepted' });
+  }
+
+  const { userId, roomNumber } = req.query;
+
+  if (!userId) {
+    console.log('유저 아이디 없음');
+    return res.status(400).json({ error: 'User ID is required' });
+  }
+
+  if (!roomNumber) {
+    console.log('방 번호 없음');
+    return res.status(400).json({ error: 'Room Number is required' });
+  }
+
+  try {
+    const roomRef = admin.firestore().collection('rooms').doc(roomNumber);
+
+    // 트랜잭션 시작
+    await admin.firestore().runTransaction(async (transaction) => {
+      const roomSnapshot = await transaction.get(roomRef);
+      const roomData = roomSnapshot.data();
+
+      if (!roomData) {
+        throw new Error('Room not found');
+      }
+
+      const userData = roomData.players.find((player) => player.id === userId);
+
+      if (!userData) {
+        throw new Error('Player data not found');
+      }
+
+      const playersCount = roomData.players.length;
+      const submitCount = roomData.submits ? roomData.submits.length : 0;
+
+      // 이미 제출한 사용자인지 확인
+      const hasSubmitted = roomData.submits ? roomData.submits.some((submit) => submit.player.id === userId) : false;
+
+      if (hasSubmitted) {
+        throw new Error('User has already submitted an answer');
+      }
+
+      const answer = {
+        player: userData,
+        music: req.body,
+      };
+
+      // 제출 업데이트
+      transaction.update(roomRef, {
+        submits: FieldValue.arrayUnion(answer),
+      });
+
+      // 모든 플레이어가 제출했는지 확인
+      if (submitCount + 1 === playersCount) {
+        transaction.update(roomRef, {
+          status: 'result',
+        });
+      }
+    });
+
+    res.status(200).json({ status: 'success' });
+  } catch (error) {
+    console.error('에러 발생:', error);
+    res.status(500).json({ error: error.message });
+  }
+});

--- a/firebase/functions/api/SubmitMusicV2.js
+++ b/firebase/functions/api/SubmitMusicV2.js
@@ -1,0 +1,83 @@
+const { FieldValue } = require('firebase-admin/firestore');
+const { onRequest } = require('firebase-functions/v2/https');
+const admin = require('../FirebaseAdmin.js');
+
+module.exports.submitMusicV2 = onRequest({ region: 'asia-southeast1' }, async (req, res) => {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Only POST requests are accepted' });
+  }
+
+  const { userId, roomNumber } = req.query;
+  if (!userId) {
+    console.log('유저 아이디 없음');
+    return res.status(400).json({ error: 'User ID is required' });
+  }
+  if (!roomNumber) {
+    console.log('방 번호 없음');
+    return res.status(400).json({ error: 'Room Number is required' });
+  }
+
+  try {
+    const roomRef = admin.firestore().collection('rooms').doc(roomNumber);
+
+    await admin.firestore().runTransaction(async (transaction) => {
+      const roomSnapshot = await transaction.get(roomRef);
+      const roomData = roomSnapshot.data();
+      const userData = roomData.players.find((player) => player.id === userId);
+
+      if (!userData) {
+        throw new Error('Player data not found');
+      }
+
+      const currentAnswer = roomData.answers.length;
+      const playersCount = roomData.players.length;
+
+      const currentMode = roomData.mode;
+      switch (currentMode) {
+        case 'humming':
+          const currentTime = new Date();
+          const dueTime = new Date(currentTime.getTime() + 1 * 60 * 1000);
+
+          let answer;
+          if (!req.body) {
+            answer = {
+              player: userData,
+            };
+          } else {
+            answer = {
+              player: userData,
+              music: req.body,
+            };
+          }
+
+          // 이미 제출한 사용자인지 확인
+          const hasSubmitted = roomData.answers.some((ans) => ans.player.id === userId);
+          if (hasSubmitted) {
+            throw new Error('User has already submitted');
+          }
+
+          // 답변 추가
+          transaction.update(roomRef, {
+            answers: FieldValue.arrayUnion(answer),
+          });
+
+          // 모든 사용자가 제출했는지 확인
+          if (currentAnswer + 1 === playersCount) {
+            transaction.update(roomRef, {
+              round: 1,
+              dueTime: dueTime,
+            });
+          }
+          break;
+        default:
+          console.log('잘못된 모드');
+          break;
+      }
+    });
+
+    res.status(200).json({ status: 'success' });
+  } catch (error) {
+    console.error('Error submitting music:', error);
+    res.status(500).json({ error: error.message });
+  }
+});

--- a/firebase/functions/api/UploadRecordV2.js
+++ b/firebase/functions/api/UploadRecordV2.js
@@ -1,0 +1,148 @@
+// TODO: 녹음파일을 업로드하는 API입니다.
+// Stroage에 파일을 저장하고, 해당 URL을 rooms/{RoomID}/records 컬렉션에 저장합니다.
+
+const { onRequest } = require('firebase-functions/v2/https');
+const admin = require('../FirebaseAdmin.js');
+const { v4: uuidv4 } = require('uuid');
+const { FieldValue } = require('firebase-admin/firestore');
+const express = require('express');
+const { Readable } = require('stream');
+const cors = require('cors');
+const bodyParser = require('body-parser');
+const fileParser = require('express-multipart-file-parser');
+
+const app = express();
+app.use(fileParser);
+app.use(cors({ origin: true }));
+app.use(bodyParser.urlencoded({ extended: true }));
+
+app.post('/v2-uploadRecording', async (req, res) => {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Only POST requests are accepted' });
+  }
+
+  const { roomNumber, userId } = req.query;
+
+  if (!roomNumber || !userId) {
+    return res.status(400).json({ error: 'Room number and user ID are required' });
+  }
+
+  const file = req.files[0];
+
+  if (!file) {
+    return res.status(400).json({ error: 'File is required' });
+  }
+
+  console.log('Received file:', file);
+
+  try {
+    const storage = admin.storage().bucket();
+    const uuid = uuidv4();
+    const fileName = `audios/${uuid}_${file.originalname}`;
+    const fileUpload = storage.file(fileName);
+
+    const fileStream = Readable.from(file.buffer);
+    const writeStream = fileUpload.createWriteStream({
+      metadata: {
+        contentType: file.mimetype,
+      },
+    });
+
+    // 파일 업로드를 Promise로 처리
+    await new Promise((resolve, reject) => {
+      fileStream.pipe(writeStream).on('finish', resolve).on('error', reject);
+    });
+
+    // 파일에 대한 공개 URL 생성
+    await fileUpload.makePublic();
+    const publicUrl = `https://storage.googleapis.com/${storage.name}/${fileName}`;
+
+    const roomRef = admin.firestore().collection('rooms').doc(roomNumber);
+
+    // 트랜잭션 시작
+    await admin.firestore().runTransaction(async (transaction) => {
+      const roomSnapshot = await transaction.get(roomRef);
+      const roomData = roomSnapshot.data();
+
+      const playerExists = roomData.players.some((player) => player.id === userId);
+
+      if (!playerExists) {
+        throw new Error('User not in the room');
+      }
+
+      const userData = roomData.players.find((player) => player.id === userId);
+
+      if (!userData) {
+        throw new Error('User not found');
+      }
+
+      const playersCount = roomData.players.length;
+      const currentRound = roomData.round || 0;
+      const currentOrderRecord = roomData.recordOrder || 0;
+      const currentMode = roomData.mode;
+      const currentAnswer = roomData.answers;
+      const currentAnswersCount = currentAnswer.length;
+
+      // 현재 라운드의 녹음 데이터를 필터링
+      const currentRoundRecords = roomData.records
+        ? roomData.records.filter((record) => record.recordOrder === currentOrderRecord)
+        : [];
+
+      console.log('-------------------------------------');
+      console.log(`현재 라운드: ${currentRound}`);
+      console.log(`현재 라운드 녹음 수: ${currentRoundRecords.length}`);
+      console.log(`플레이어 수: ${playersCount}`);
+      console.log(`현재 모드: ${currentMode}`);
+      console.log(`현재 OrderRecord: ${currentOrderRecord}`);
+      console.log(`현재 라운드(OrderRecord) 녹음: ${currentRoundRecords.length}`);
+      console.log(`현재 Answer 수: ${currentAnswersCount}`);
+      console.log(`현재 Answer: ${currentAnswer}`);
+      console.log('-------------------------------------');
+
+      switch (currentMode) {
+        case 'humming':
+          const currentTime = new Date();
+          const dueTime = new Date(currentTime.getTime() + 1 * 60 * 1000);
+
+          const record = {
+            player: userData,
+            recordOrder: currentOrderRecord,
+            fileUrl: publicUrl,
+          };
+
+          // 이미 제출한 사용자인지 확인
+          const hasSubmitted = currentRoundRecords.some((rec) => rec.player.id === userId);
+
+          if (hasSubmitted) {
+            throw new Error('User has already submitted');
+          }
+
+          // 녹음 데이터 추가
+          transaction.update(roomRef, {
+            records: FieldValue.arrayUnion(record),
+          });
+
+          // 모든 사용자가 제출했는지 확인
+          if (currentRoundRecords.length + 1 === playersCount) {
+            transaction.update(roomRef, {
+              recordOrder: currentOrderRecord + 1,
+              status: 'rehumming',
+              dueTime: dueTime,
+            });
+          }
+          break;
+        default:
+          console.log('Invalid mode');
+          throw new Error('Invalid mode');
+      }
+    });
+
+    res.status(200).send({ success: true });
+  } catch (error) {
+    console.error('Error during file upload or Firestore transaction:', error);
+    return res.status(500).json({ error: error.message });
+  }
+});
+
+// Cloud Function 내보내기
+module.exports.uploadRecordingV2 = onRequest({ region: 'asia-southeast1' }, app);

--- a/firebase/functions/index.js
+++ b/firebase/functions/index.js
@@ -1,10 +1,7 @@
-const { onRequest } = require('firebase-functions/v2/https');
-const admin = require('./FirebaseAdmin.js');
 const { createRoom } = require('./api/CreateRoom.js');
 const { joinRoom } = require('./api/JoinRoom.js');
 const { startGame } = require('./api/StartGame.js');
 const { uploadRecord } = require('./api/UploadRecord.js');
-// const { onRecordAdded } = require('./trigger/onRecordAdded.js');
 const { exitRoom } = require('./api/ExitRoom.js');
 const { onRemovePlayer, onRemoveRoom } = require('./trigger/onRemovePlayer.js');
 const { changeMode } = require('./api/ChangeMode.js');
@@ -12,6 +9,10 @@ const { submitMusic } = require('./api/SubmitMusic');
 const { submitAnswer } = require('./api/SubmitAnswer');
 const { changeRecordOrder } = require('./api/ChangeRecordOrder.js');
 const { resetGame } = require('./api/ResetGame.js');
+
+const { submitMusicV2 } = require('./api/SubmitMusicV2.js');
+const { submitAnswerV2 } = require('./api/SubmitAnswerV2.js');
+const { uploadRecordingV2 } = require('./api/UploadRecordV2.js');
 
 // 방 관련 API
 exports.createRoom = createRoom;
@@ -24,15 +25,13 @@ exports.submitMusic = submitMusic;
 exports.submitAnswer = submitAnswer;
 exports.changeRecordOrder = changeRecordOrder;
 exports.resetGame = resetGame;
-
-// GameStart API
+exports.onRemovePlayer = onRemovePlayer;
 exports.startGame = startGame;
-
-// 녹음파일 업로드 API
 exports.uploadRecording = uploadRecord;
 
-// Record 추가 트리거 (미완)
-// exports.onRecordAdded = onRecordAdded;
-
-// 방 나갈 경우 자동으로 삭제 트리거
-exports.onRemovePlayer = onRemovePlayer;
+exports.V2 = {
+  uploadRecording: uploadRecordingV2,
+  submitMusic: submitMusicV2,
+  submitAnswer: submitAnswerV2,
+};
+∑


### PR DESCRIPTION
* DB 트랜젝션 적용

## What is this PR?
- 4명이서 노래를 제출하거나 마지막 사람의 녹음을 전달할 때는, 모든 플레이어의 화면이 다음 녹음 화면 으로 이동해야하지만, 간혹 마지막 사람이 녹음파일을 보내더라도 다음화면으로 전환이 되지않는 오작동이 일어났던 문제를 해결했습니다.

## PR Type
- [x] Bugfix
- [ ] Chore
- [ ] New feature (기능을 추가하는 feat)
- [ ] Breaking change (기존의 기능이 동작하지 않을 수 있는 fix/feat)
- [ ] Documentation Update

## ScreenShot(if available)
|기능|스크린샷|
|:--:|:--:|
|노래 제출|<img src = "https://github.com/user-attachments/assets/ea9e23e9-65ae-4b27-8624-26e9f36315e5" width ="250">|
|허밍 제출|<img src = "https://github.com/user-attachments/assets/3234a21f-0510-4029-8eb3-8c54c7e104a7" width ="250">|
|정답 제출|<img src = "https://github.com/user-attachments/assets/8477cebe-4e3a-4ac0-b1a7-baf479592adf" width ="250">|


## Further comments

* 기존 API를 사용하는 브랜치도 존재하기 때문에 새로운 Endpoint Path를 만들었습니다.
```swift
// FirebaseEndpoint.swift
...
  case .uploadRecording:
      "/v2-uploadRecording"
  case .submitMusic:
      "/v2-submitMusic"
  case .submitAnswer:
      "/v2-submitAnswer"
...
```

### 왜 발생했는가 ?

서버와 클라이언트는 어떤 작업하는지 구체적으로 설명드리겠습니다.

- **서버는 마지막 녹음의 제출인 경우  DB의 rooms/{roomNumber}/ 경로에 저장되어있는 RecordOrder를 1 증가시킨다.**
- **클라이언트는 다음녹음을 하러 가야하는지 확인하기 위해 DB의 rooms/{roomNumber}/ 경로에 저장되어있는, RecordOrder를 확인한다. RecordOrder가 변경되면 다음 네비게이션으로 Push한다.**

여기서 발생하는 문제는, 서버에서는 사용자의 요청이 들어오면, 음성파일의 갯수를 Read 후 Snapshot을 찍은 뒤, await update를 하고있는 중입니다.

하지만 동시에 사용자가 요청을 보내는 경우에는, DB에 저장된, 녹음파일의 갯수를 읽어 오는 시점이 똑같기 때문에,  Snapshot이 일치하는 현상이 발생합니다.

따라서 서버입장에서는 아직 녹음파일이 덜 제출됬는데? 라고 생각하게 됩니다.

일종의 서버에서 발생하는 Race Condition 문제라고 생각하였습니다.

Race Condition이란 공유 자원에 대해 동시에 접근할 때 누가 언제 데이터를 읽거나 쓰느냐에 따라 결과가 달라질 수 있는 문제입니다.

### 어떻게 해결했는가 ?

Firebase는 동시성을 보장하지 못하는건가 생각이 들었고, 예전에 학습햇었던 DB의 Transaction의 특징이 떠올습니다.

트랜잭션이란? **더이상 나누어질 수 없는 최소한의 단위** 이다.  4가지 특징이 있는데,

- 원자성(Atomicity)
    
    > 트랜잭션이 DB에 모두 반영되거나, 혹은 전혀 반영되지 않아야 된다.
    
- 일관성(Consistency)
    
    > 트랜잭션의 작업 처리 결과는 항상 일관성 있어야 한다.
    
- 독립성(Isolation)
    
    > 둘 이상의 트랜잭션이 동시에 병행 실행되고 있을 때, 어떤 트랜잭션도 다른 트랜잭션 연산에 끼어들 수 없다.
    
- 지속성(Durability)
    
    > 트랜잭션이 성공적으로 완료되었으면, 결과는 영구적으로 반영되어야 한다.
    
즉 트랜젝션을 만드련 여러 개의 쿼리 또는 데이터 조작 작업을 하나로 묶어서 전체 작업이 원자적(Atomic)으로 수행되도록 보장하게 됩니다.

트렌젝션을 통해 작업을 묶는 방법은 공식문서를 참고하였습니다. 

https://firebase.google.com/docs/firestore/manage-data/transactions?hl=ko 

파이어 베이스의 트렌젝션은 동시 수정을 할 경우 Cloud Firestore는 전체 트랜잭션을 다시 실행합니다.

한 트랜잭션에서 문서를 읽고 다른 클라이언트가 이 문서를 수정할 경우 Cloud Firestore는 이 트랜잭션을 다시 시도하는 것을 활용하여 해결하였습니다.



