### PR TITLE
feat: 결과화면에서 로비로 이동, 결과화면 로딩 Alert 추가

### DIFF
--- a/alsongDalsong/ASNetworkKit/ASNetworkKit/FirebaseEndpoint.swift
+++ b/alsongDalsong/ASNetworkKit/ASNetworkKit/FirebaseEndpoint.swift
@@ -28,6 +28,7 @@ public struct FirebaseEndpoint: Endpoint, Equatable {
         case changeRecordOrder
         case submitMusic
         case submitAnswer
+        case resetGame
       
         public var description: String {
             switch self {
@@ -49,6 +50,8 @@ public struct FirebaseEndpoint: Endpoint, Equatable {
                     "/submitAnswer"
                 case .changeRecordOrder:
                     "/changeRecordOrder"
+                case .resetGame:
+                    "/resetGame"
             }
         }
     }

--- a/alsongDalsong/ASRepository/ASRepository/Protocols/MainRepositoryProtocol.swift
+++ b/alsongDalsong/ASRepository/ASRepository/Protocols/MainRepositoryProtocol.swift
@@ -21,4 +21,5 @@ public protocol MainRepositoryProtocol {
     func disconnectRoom()
     
     func postRecording(_ record: Data) async throws -> Bool
+    func postResetGame() async throws -> Bool
 }

--- a/alsongDalsong/ASRepository/ASRepository/Protocols/RepositoryProtocols.swift
+++ b/alsongDalsong/ASRepository/ASRepository/Protocols/RepositoryProtocols.swift
@@ -58,6 +58,7 @@ public protocol RoomActionRepositoryProtocol {
     func startGame(roomNumber: String) async throws -> Bool
     func changeMode(roomNumber: String, mode: Mode) async throws -> Bool
     func changeRecordOrder(roomNumber: String) async throws -> Bool
+    func resetGame() async throws -> Bool
 }
 
 public protocol MusicRepositoryProtocol {

--- a/alsongDalsong/ASRepository/ASRepository/Repositories/MainRepository.swift
+++ b/alsongDalsong/ASRepository/ASRepository/Repositories/MainRepository.swift
@@ -102,4 +102,22 @@ public final class MainRepository: MainRepositoryProtocol {
         guard let success = responseDict["success"] else { return false }
         return success
     }
+    
+    public func postResetGame() async throws -> Bool {
+        let queryItems = [URLQueryItem(name: "userId", value: ASFirebaseAuth.myID),
+                          URLQueryItem(name: "roomNumber", value: number.value)]
+        let endPoint = FirebaseEndpoint(path: .resetGame, method: .post)
+            .update(\.queryItems, with: queryItems)
+
+        let response = try await networkManager.sendRequest(
+            to: endPoint,
+            type: .none,
+            body: nil,
+            option: .none
+        )
+        
+        let responseDict = try ASDecoder.decode([String: Bool].self, from: response)
+        guard let success = responseDict["success"] else { return false }
+        return success
+    }
 }

--- a/alsongDalsong/ASRepository/ASRepository/Repositories/RoomActionRepository.swift
+++ b/alsongDalsong/ASRepository/ASRepository/Repositories/RoomActionRepository.swift
@@ -82,6 +82,10 @@ public final class RoomActionRepository: RoomActionRepositoryProtocol {
         return isSuccess
     }
     
+    public func resetGame() async throws -> Bool {
+        return try await mainRepository.postResetGame()
+    }
+    
     private func sendRequest<T: Decodable>(endpointPath: FirebaseEndpoint.Path, requestBody: [String: Any]) async throws -> T {
         let endpoint = FirebaseEndpoint(path: endpointPath, method: .post)
         let body = try JSONSerialization.data(withJSONObject: requestBody, options: [])

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/ASAlertController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/ASAlertController.swift
@@ -366,12 +366,14 @@ enum ASAlertText {
         case startGame
         case submitMusic
         case submitHumming
+        case nextResult
         var description: String {
             switch self {
                 case .joinRoom: "방 정보를 가져오는 중..."
                 case .startGame: "게임을 시작하는 중..."
                 case .submitMusic: "노래를 전송하는 중..."
                 case .submitHumming: "허밍을 전송하는 중..."
+                case .nextResult: "다음 결과를 가져오는 중..."
             }
         }
     }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/ASButton.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/ASButton.swift
@@ -54,11 +54,11 @@ final class ASButton: UIButton {
 
         configurationUpdateHandler = { [weak self] _ in
             guard let self else { return }
-            if self.isHighlighted {
-                self.transform = CGAffineTransform(scaleX: 0.96, y: 0.96)
+            if isHighlighted {
+                transform = CGAffineTransform(scaleX: 0.96, y: 0.96)
             }
             else {
-                self.transform = .identity
+                transform = .identity
             }
         }
         configuration = config
@@ -91,7 +91,7 @@ final class ASButton: UIButton {
             case .recording: setConfiguration(title: "녹음중..", backgroundColor: .asLightRed)
             case .reRecord: setConfiguration(systemImageName: "arrow.clockwise", title: "재녹음", backgroundColor: .asOrange)
             case .submit: setConfiguration(title: "제출하기", backgroundColor: .asGreen)
-            case .complete: setConfiguration(title: "완료")
+            case .complete: setConfiguration(title: "완료", backgroundColor: .asYellow)
             case .submitted:
                 setConfiguration(title: "제출 완료")
                 disable()

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Result/HummingResultViewController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Result/HummingResultViewController.swift
@@ -42,16 +42,8 @@ class HummingResultViewController: UIViewController {
         button.setConfiguration(systemImageName: "play.fill", title: "다음으로", backgroundColor: .asMint)
         view.addSubview(button)
         button.addAction(UIAction { [weak self] _ in
-            guard let self,
-                  let viewModel else { return }
-            if !(viewModel.hummingResult.isEmpty) {
-                viewModel.changeRecordOrder()
-            }
-            else {
-//                let vc = self.navigationController?.viewControllers.first(where: { $0 is LobbyViewController })
-//                guard let vc else { return }
-//                self.navigationController?.popToViewController(vc, animated: true)
-            }
+            guard let self, let viewModel else { return }
+            showNextResultLoading()
         }, for: .touchUpInside)
         button.isHidden = true
     }
@@ -118,12 +110,27 @@ class HummingResultViewController: UIViewController {
                     viewModel.nextResultFetch()
                     button.isHidden = true
                     if viewModel.hummingResult.isEmpty {
-                        button.setConfiguration(title: "완료", backgroundColor: .asYellow)
+                        button.updateButton(.complete)
                     }
                     viewModel.isNext = false
                 }
             }
             .store(in: &cancellables)
+    }
+    
+    private func nextResultFetch() async throws {
+        guard let viewModel else { return }
+        do {
+            if viewModel.hummingResult.isEmpty {
+                try await viewModel.navigationToLobby()
+            }
+            else {
+                try await viewModel.changeRecordOrder()
+            }
+        }
+        catch {
+            throw error
+        }
     }
 }
 
@@ -238,6 +245,26 @@ extension HummingResultViewController: UITableViewDataSource {
     }
 }
 
+extension HummingResultViewController {
+    private func showNextResultLoading() {
+        let alert = ASAlertController(
+            progressText: .nextResult,
+            load: { [weak self] in
+                try await self?.nextResultFetch()
+            },
+            errorCompletion: { [weak self] error in
+                self?.showFailNextLoading(error)
+            }
+        )
+        presentLoadingView(alert)
+    }
+    
+    private func showFailNextLoading(_ error: Error) {
+        let alert = ASAlertController(titleText: .error(error))
+        presentAlert(alert)
+    }
+}
+
 final class MusicResultView: UIView {
     private let albumImageView = UIImageView()
     private let musicNameLabel = UILabel()
@@ -284,7 +311,7 @@ final class MusicResultView: UIView {
     }
 
     private func setupView() {
-        self.backgroundColor = .asSystem
+        backgroundColor = .asSystem
         
         titleLabel.text = "정답은..."
         titleLabel.font = .font(ofSize: 24)

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Result/HummingResultViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Result/HummingResultViewModel.swift
@@ -1,9 +1,9 @@
-import Foundation
-import Combine
-import ASRepositoryProtocol
 import ASAudioKit
 import ASEntity
 import ASLogKit
+import ASRepositoryProtocol
+import Combine
+import Foundation
 
 final class HummingResultViewModel: @unchecked Sendable {
     private var hummingResultRepository: HummingResultRepositoryProtocol
@@ -35,7 +35,8 @@ final class HummingResultViewModel: @unchecked Sendable {
          playerRepository: PlayersRepositoryProtocol,
          roomActionRepository: RoomActionRepositoryProtocol,
          roomInfoRepository: RoomInfoRepositoryProtocol,
-         musicRepository: MusicRepositoryProtocol) {
+         musicRepository: MusicRepositoryProtocol)
+    {
         self.hummingResultRepository = hummingResultRepository
         self.avatarRepository = avatarRepository
         self.gameStatusRepository = gameStatusRepository
@@ -51,7 +52,7 @@ final class HummingResultViewModel: @unchecked Sendable {
         hummingResultRepository.getResult()
             .receive(on: DispatchQueue.main)
             .sink { completion in
-                //TODO: 성공 실패 여부에 따른 처리
+                // TODO: 성공 실패 여부에 따른 처리
                 Logger.debug(completion)
             } receiveValue: { [weak self] (result: [(answer: ASEntity.Answer, records: [ASEntity.Record], submit: ASEntity.Answer, recordOrder: UInt8)]) in
                 // 분명 받았던 데이터인데 계속 값이 들어옴
@@ -59,20 +60,20 @@ final class HummingResultViewModel: @unchecked Sendable {
                 
                 if (result.count - 1) < result.first?.recordOrder ?? 0 { return }
                 Logger.debug("호출")
-                self.hummingResult = result.map {
-                    return (answer: $0.answer, records: $0.records, submit: $0.submit)
+                hummingResult = result.map {
+                    (answer: $0.answer, records: $0.records, submit: $0.submit)
                 }
                 
-                self.hummingResult.sort {
+                hummingResult.sort {
                     $0.answer.player?.order ?? 0 < $1.answer.player?.order ?? 1
                 }
                 
-                Logger.debug("hummingResult \(self.hummingResult)")
+                Logger.debug("hummingResult \(hummingResult)")
 
-                let current = self.hummingResult.removeFirst()
-                self.currentResult = current.answer
-                self.recordsResult = current.records
-                self.submitsResult = current.submit
+                let current = hummingResult.removeFirst()
+                currentResult = current.answer
+                recordsResult = current.records
+                submitsResult = current.submit
             }
             .store(in: &cancellables)
         
@@ -92,32 +93,31 @@ final class HummingResultViewModel: @unchecked Sendable {
         
         Publishers.CombineLatest(gameStatusRepository.getStatus(), gameStatusRepository.getRecordOrder())
             .receive(on: DispatchQueue.main)
-            .sink { status, order in
+            .sink { status, _ in
                 // order에 초기값이 들어오는 문제
-                if (status == .result && self.recordOrder != 0) {
+                if status == .result, self.recordOrder != 0 {
                     self.recordOrder! += 1
                     self.isNext = true
-                }
-                else {
+                } else {
                     self.recordOrder! += 1
                 }
             }
             .store(in: &cancellables)
     }
     
-    func startPlaying() async -> Void {
-            while !recordsResult.isEmpty {
-                currentRecords.append(recordsResult.removeFirst())
-                guard let fileUrl = currentRecords.last?.fileUrl else { continue }
-                do {
-                    let data = try await fetchRecordData(url: fileUrl)
-                    await AudioHelper.shared.startPlaying(data)
-                    await waitForPlaybackToFinish()
-                } catch {
-                    Logger.error("녹음 파일 다운로드에 실패하였습니다.")
-                }
+    func startPlaying() async {
+        while !recordsResult.isEmpty {
+            currentRecords.append(recordsResult.removeFirst())
+            guard let fileUrl = currentRecords.last?.fileUrl else { continue }
+            do {
+                let data = try await fetchRecordData(url: fileUrl)
+                await AudioHelper.shared.startPlaying(data)
+                await waitForPlaybackToFinish()
+            } catch {
+                Logger.error("녹음 파일 다운로드에 실패하였습니다.")
             }
-            currentsubmit = submitsResult
+        }
+        currentsubmit = submitsResult
     }
     
     private func waitForPlaybackToFinish() async {
@@ -133,21 +133,21 @@ final class HummingResultViewModel: @unchecked Sendable {
     }
     
     func nextResultFetch() {
-        if self.hummingResult.isEmpty { return }
-        let current = self.hummingResult.removeFirst()
-        self.currentResult = current.answer
-        self.recordsResult = current.records
-        self.submitsResult = current.submit
-        self.currentRecords.removeAll()
-        self.currentsubmit = nil
+        if hummingResult.isEmpty { return }
+        let current = hummingResult.removeFirst()
+        currentResult = current.answer
+        recordsResult = current.records
+        submitsResult = current.submit
+        currentRecords.removeAll()
+        currentsubmit = nil
     }
     
     private func getRecordData(url: URL?) -> AnyPublisher<Data?, Error> {
         if let url {
-            return hummingResultRepository.getRecordData(url: url)
+            hummingResultRepository.getRecordData(url: url)
                 .eraseToAnyPublisher()
-        }else {
-            return Just(nil)
+        } else {
+            Just(nil)
                 .setFailureType(to: Error.self)
                 .eraseToAnyPublisher()
         }
@@ -173,13 +173,21 @@ final class HummingResultViewModel: @unchecked Sendable {
         return await avatarRepository.getAvatarData(url: url)
     }
     
-    func changeRecordOrder() {
-        Task {
-            do {
-                try await self.roomActionRepository.changeRecordOrder(roomNumber: roomNumber)
-            } catch {
-                Logger.error(error.localizedDescription)
-            }
+    func changeRecordOrder() async throws {
+        do {
+            try await roomActionRepository.changeRecordOrder(roomNumber: roomNumber)
+        } catch {
+            Logger.error(error.localizedDescription)
+            throw error
+        }
+    }
+    
+    public func navigationToLobby() async throws {
+        do {
+            if !hummingResult.isEmpty { return }
+            try await roomActionRepository.resetGame()
+        } catch {
+            throw error
         }
     }
     

--- a/firebase/functions/api/ResetGame.js
+++ b/firebase/functions/api/ResetGame.js
@@ -4,6 +4,7 @@
 
 const { onRequest } = require('firebase-functions/v2/https');
 const admin = require('../FirebaseAdmin.js');
+const { FieldValue } = require('firebase-admin/firestore');
 
 /**
  * 게임 리셋 요청을 처리하는 HTTPS 요청.
@@ -16,7 +17,7 @@ module.exports.resetGame = onRequest({ region: 'asia-southeast1' }, async (req, 
     return res.status(405).json({ error: 'Only POST requests are accepted' });
   }
 
-  const { roomNumber, userId } = req.body;
+  const { roomNumber, userId } = req.query;
   const roomRef = admin.firestore().collection('rooms').doc(roomNumber);
 
   try {
@@ -32,24 +33,22 @@ module.exports.resetGame = onRequest({ region: 'asia-southeast1' }, async (req, 
       return res.status(403).json({ error: 'Only the host can reset the game' });
     }
 
-    // 게임 관련 상태 초기화
     const updatedRoomData = {
       ...roomData,
-      mode: 'humming',
       round: 0,
-      status: null,
+      status: FieldValue.delete(),
       records: [],
       answers: [],
-      dueTime: null,
+      dueTime: FieldValue.delete(),
       selectedRecords: [],
       submits: [],
-      recordOrder: null,
+      recordOrder: FieldValue.delete(),
     };
 
     // Firestore에 업데이트
     await roomRef.set(updatedRoomData, { merge: true });
 
-    return res.status(200).json({ success: true, message: 'Game reset successfully', updatedRoomData });
+    return res.status(200).json({ success: true });
   } catch (error) {
     console.error('Error resetting game:', error);
     return res.status(500).json({ error: 'Failed to reset the game' });


### PR DESCRIPTION
## What is this PR?
-  결과화면에서 로비로 이동
-  결과화면 로딩 Alert 추가
## PR Type
- [ ] Bugfix
- [ ] Chore
- [x] New feature (기능을 추가하는 feat)
- [ ] Breaking change (기존의 기능이 동작하지 않을 수 있는 fix/feat)
- [ ] Documentation Update

## ScreenShot(if available)
|기능|스크린샷|
|:--:|:--:|
|결과 로딩|<img src = "https://github.com/user-attachments/assets/615f0443-2535-4e22-8585-d4289f6b0e58" width ="250">|
|로비 이동|<img src = "https://github.com/user-attachments/assets/8ed89b4e-3c6f-45c8-8b43-29eb77a6fb65" width ="250">|

## Further comments
* 실제로 테스트했을 때, 같은 Room에서 3회 동안 플레이하였고, 문제가 없었습니다.