### PR TITLE
feat: 재생 시 파형 색상 변경

### DIFF
--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/AudioVisualizerView.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/AudioVisualizerView.swift
@@ -127,7 +127,7 @@ final class WaveFormView: UIView {
 
             let circleLayer = CAShapeLayer()
             circleLayer.path = circle.cgPath
-            circleLayer.fillColor = UIColor.asShadow.cgColor
+            circleLayer.fillColor = UIColor.white.cgColor
 
             layer.addSublayer(circleLayer)
             columns.append(circleLayer)

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Utils/AudioHelper.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Utils/AudioHelper.swift
@@ -21,18 +21,23 @@ actor AudioHelper {
     private var source: FileSource = .imported
     private var playType: PlayType = .full
     private var isConcurrent: Bool = false
-    private var timer: Timer?
+    private var cancellable: AnyCancellable?
 
     // MARK: - Publishers
 
     private let amplitudeSubject = PassthroughSubject<Float, Never>()
     private let playerStateSubject = PassthroughSubject<(FileSource, Bool), Never>()
+    private let waveformUpdateSubject = PassthroughSubject<Int, Never>()
     private let recorderStateSubject = PassthroughSubject<Bool, Never>()
     private let recorderDataSubject = PassthroughSubject<Data, Never>()
     var amplitudePublisher: AnyPublisher<Float, Never> { amplitudeSubject.eraseToAnyPublisher() }
 
     var playerStatePublisher: AnyPublisher<(FileSource, Bool), Never> {
         playerStateSubject.eraseToAnyPublisher()
+    }
+
+    var waveformUpdatePublisher: AnyPublisher<Int, Never> {
+        waveformUpdateSubject.eraseToAnyPublisher()
     }
 
     var recorderStatePublisher: AnyPublisher<Bool, Never> {
@@ -55,9 +60,17 @@ actor AudioHelper {
         return await player.isPlaying()
     }
 
+    private func removePlayer() async {
+        player = nil
+    }
+
+    private func removeRecorder() {
+        recorder = nil
+    }
+
     private func removeTimer() {
-        timer?.invalidate()
-        timer = nil
+        cancellable?.cancel()
+        cancellable = nil
     }
 }
 
@@ -70,7 +83,7 @@ extension AudioHelper {
     ///   - source: 녹음 파일/url에서 가져온 파일
     ///   - playType: 전체 또는 부분 재생
     ///   - allowsConcurrent: 녹음과 동시에 재생
-    func startPlaying(_ file: Data?, sourceType type: FileSource = .imported) async {
+    func startPlaying(_ file: Data?, sourceType type: FileSource = .imported, needsWaveUpdate: Bool = false) async {
         guard await checkRecorderState(), await checkPlayerState() else { return }
         guard let file else { return }
 
@@ -80,13 +93,31 @@ extension AudioHelper {
             await self?.stopPlaying()
         }
         sendDataThrough(playerStateSubject, (source, true))
+        if needsWaveUpdate {
+            updatePlayIndex()
+        }
         await player?.startPlaying(data: file, option: playType)
     }
 
     func stopPlaying() async {
         await player?.stopPlaying()
-        player = nil
+        await removePlayer()
         sendDataThrough(playerStateSubject, (source, false))
+        removeTimer()
+    }
+
+    private func updatePlayIndex() {
+        cancellable = Timer.publish(every: 0.125, on: .main, in: .common)
+            .autoconnect()
+            .scan(0) { count, _ in
+                count + 1
+            }
+            .sink { [weak self] value in
+                guard let self else { return }
+                Task {
+                    await self.sendDataThrough(self.waveformUpdateSubject, value - 1)
+                }
+            }
     }
 
     private func makePlayer() {
@@ -96,6 +127,7 @@ extension AudioHelper {
     private func checkPlayerState() async -> Bool {
         if await isPlaying() {
             await player?.stopPlaying()
+            await removePlayer()
             sendDataThrough(playerStateSubject, (source, false))
         }
         return true
@@ -113,6 +145,7 @@ extension AudioHelper {
         recorderStateSubject.send(true)
         await recorder?.startRecording(url: tempURL)
         visualize()
+        Logger.debug("녹음 시작")
         do {
             try await Task.sleep(nanoseconds: 6 * 1_000_000_000)
             let recordedData = await stopRecording()
@@ -123,8 +156,9 @@ extension AudioHelper {
 
     private func stopRecording() async -> Data? {
         let recordedData = await recorder?.stopRecording()
+        Logger.debug("녹음 정지")
         recorderStateSubject.send(false)
-        recorder = nil
+        removeRecorder()
         return recordedData
     }
 
@@ -190,17 +224,20 @@ extension AudioHelper {
     private func visualize() {
         Task { [weak self] in
             guard let self else { return }
-            await self.setTimer()
+            await self.calculateAmplitude()
         }
     }
 
-    private func setTimer() {
-        timer = Timer(timeInterval: 0.125, repeats: true) { [weak self] _ in
-            Task {
-                await self?.calculateRecorderAmplitude()
+    private func calculateAmplitude() {
+        Logger.debug("진폭계산 시작")
+        cancellable = Timer.publish(every: 0.125, on: .main, in: .common)
+            .autoconnect()
+            .sink { [weak self] value in
+                guard let self else { return }
+                Task {
+                    await self.calculateRecorderAmplitude()
+                }
             }
-        }
-        RunLoop.main.add(timer!, forMode: .common)
     }
 
     private func calculateRecorderAmplitude() async {

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/RecordingPanel/RecordingPanelViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/RecordingPanel/RecordingPanelViewModel.swift
@@ -2,6 +2,7 @@ import Combine
 import Foundation
 
 final class RecordingPanelViewModel: @unchecked Sendable {
+    let sampleCount: Int = 48
     @Published var recordedData: Data?
     @Published public private(set) var recorderAmplitude: Float = 0.0
     @Published public private(set) var buttonState: AudioButtonState = .idle


### PR DESCRIPTION
## What is this PR?
- 재생 시 맞춰서 파형 색상이 변경되도록 했습니다.
- 오디오가 자동으로 멈추면 다시 원래 색상으로 변경되도록 했습니다.

## PR Type
- [ ] Bugfix
- [ ] Chore
- [x] New feature (기능을 추가하는 feat)
- [ ] Breaking change (기존의 기능이 동작하지 않을 수 있는 fix/feat)
- [ ] Documentation Update

## ScreenShot(if available)
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "https://github.com/user-attachments/assets/58b8bdd3-b15a-4f07-96d5-7fffad291878" width ="250">|

## Further comments
- AudioHelper에서 변경점이 많이 생겼습니다. 우선 재생, 녹음, 설정, 파형생성 등을 extension으로 분리했고, 기존 Runloop에 timer를 직접 붙이던 것을 Combine을 사용하도록 바꿨습니다.
- Combine으로 타이머를 바꾸면서 재생 함수에 매개변수를 추가했습니다.
```swift
    func startPlaying(
        _ file: Data?,
        sourceType type: FileSource = .imported,
        needsWaveUpdate: Bool = false
    ) async {
``` 
`needsWaveUpdater`를 true로 설정하면 오디오를 재생함과 동시에 `waveformUpdateSubject`에서 0.125초마다 0에서 1씩 올리는 이벤트를 방출합니다. RecordingPanelViewModel은 이 이벤트를 구독하고, 업데이트될 때마다 RecordingPanelViewController -> WaveFormView의 방향으로 이벤트를 전달하여 해당 인덱스의 column 색상을 바꾸게 됩니다.
```swift
    fileprivate func updatePlayingIndex(_ index: Int) {
        columns[index].fillColor = UIColor.black.cgColor
    }
``` 
재생이 모두 끝났을 때는 검은색으로 변경됐던 파형이 원래 색상으로 돌아와야 하기 때문에, 버튼의 상태를 옵저빙하던 함수가 다음 함수를 실행하도록 하였습니다.
```swift
// RecordingPanel.swift
        viewModel.$buttonState
            .receive(on: DispatchQueue.main)
            .sink { [weak self] state in
                self?.updateButtonImage(with: state)
                self?.updateWaveForm(state: state)
            }
            .store(in: &cancellables)
// WaveForm.swift
    fileprivate func resetColor() {
        for column in columns {
            column.fillColor = UIColor.white.cgColor
        }
    }
``` 