### PR TITLE
fix: 노래 검색, 정답 제출 1차QA

### DIFF
--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SelectMusic/SelectMusicView.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SelectMusic/SelectMusicView.swift
@@ -14,7 +14,9 @@ struct SelectMusicView: View {
                 .scaleEffect(1.1)
                 Spacer()
                 Button {
-                    viewModel.isPlaying.toggle()
+                    if viewModel.selectedMusic != nil {
+                        viewModel.isPlaying.toggle()
+                    }
                 } label: {
                     if #available(iOS 17.0, *) {
                         Image(systemName: viewModel.isPlaying ? "stop.fill" : "play.fill")

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SelectMusic/SelectMusicView.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SelectMusic/SelectMusicView.swift
@@ -51,7 +51,7 @@ struct SelectMusicView: View {
                     Spacer()
                 }
             } else {
-                if viewModel.searchList.isEmpty {
+                if viewModel.isSearching {
                     VStack {
                         Spacer()
                         ProgressView()
@@ -70,10 +70,12 @@ struct SelectMusicView: View {
                         }
                     }
                     .listStyle(.plain)
+                    .scrollDismissesKeyboard(.immediately)
                 }
             }
         }
         .background(.asLightGray)
+        
     }
 }
 

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SelectMusic/SelectMusicView.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SelectMusic/SelectMusicView.swift
@@ -17,11 +17,11 @@ struct SelectMusicView: View {
                     viewModel.isPlaying.toggle()
                 } label: {
                     if #available(iOS 17.0, *) {
-                        Image(systemName: viewModel.isPlaying ? "pause.fill" : "play.fill")
+                        Image(systemName: viewModel.isPlaying ? "stop.fill" : "play.fill")
                             .font(.largeTitle)
                             .contentTransition(.symbolEffect(.replace.offUp))
                     } else {
-                        Image(systemName: viewModel.isPlaying ? "pause.fill" : "play.fill")
+                        Image(systemName: viewModel.isPlaying ? "stop.fill" : "play.fill")
                             .font(.largeTitle)
                     }
                 }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SelectMusic/SelectMusicView.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SelectMusic/SelectMusicView.swift
@@ -58,6 +58,7 @@ struct SelectMusicView: View {
                             .scaleEffect(2.0)
                         Spacer()
                     }
+                    .scrollDismissesKeyboard(.immediately)
                 } else {
                     List(viewModel.searchList) { music in
                         Button {
@@ -75,7 +76,6 @@ struct SelectMusicView: View {
             }
         }
         .background(.asLightGray)
-        
     }
 }
 

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SelectMusic/SelectMusicViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SelectMusic/SelectMusicViewModel.swift
@@ -109,10 +109,10 @@ final class SelectMusicViewModel: ObservableObject, @unchecked Sendable {
     public func searchMusic(text: String) async throws {
         do {
             if text.isEmpty { return }
-            isSearching = true
+            await updateIsSearching(with: true)
             let searchList = try await musicAPI.search(for: text)
             await updateSearchList(with: searchList)
-            isSearching = false
+            await updateIsSearching(with: false)
         } catch {
             throw error
         }
@@ -145,6 +145,11 @@ final class SelectMusicViewModel: ObservableObject, @unchecked Sendable {
     @MainActor
     private func updateSearchList(with searchList: [Music]) {
         self.searchList = searchList
+    }
+    
+    @MainActor
+    private func updateIsSearching(with isSearching: Bool) {
+        self.isSearching = isSearching
     }
     
     public func cancelSubscriptions() {

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SelectMusic/SelectMusicViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SelectMusic/SelectMusicViewModel.swift
@@ -7,6 +7,7 @@ import Foundation
 final class SelectMusicViewModel: ObservableObject, @unchecked Sendable {
     @Published public private(set) var answers: [Answer] = []
     @Published public private(set) var searchList: [Music] = []
+    @Published public private(set) var isSearching: Bool = false
     @Published public private(set) var dueTime: Date?
     @Published public private(set) var selectedMusic: Music?
     @Published public private(set) var submissionStatus: (submits: String, total: String) = ("0", "0")
@@ -96,19 +97,22 @@ final class SelectMusicViewModel: ObservableObject, @unchecked Sendable {
         beginPlaying()
     }
     public func submitMusic() async throws {
-        guard let selectedMusic else { return }
-        do {
-            _ = try await answersRepository.submitMusic(answer: selectedMusic)
-        } catch {
-            throw error
+        if let selectedMusic {
+            do {
+                _ = try await answersRepository.submitMusic(answer: selectedMusic)
+            } catch {
+                throw error
+            }
         }
     }
  
     public func searchMusic(text: String) async throws {
         do {
             if text.isEmpty { return }
+            isSearching = true
             let searchList = try await musicAPI.search(for: text)
             await updateSearchList(with: searchList)
+            isSearching = false
         } catch {
             throw error
         }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SubmitAnswer/SelectAnswerView.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SubmitAnswer/SelectAnswerView.swift
@@ -17,7 +17,9 @@ struct SelectAnswerView: View {
                     .scaleEffect(1.1)
                     Spacer()
                     Button {
-                        viewModel.isPlaying.toggle()
+                        if viewModel.selectedMusic != nil {
+                            viewModel.isPlaying.toggle()
+                        }
                     } label: {
                         if #available(iOS 17.0, *) {
                             Image(systemName: viewModel.isPlaying ? "stop.fill" : "play.fill")

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SubmitAnswer/SelectAnswerView.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SubmitAnswer/SelectAnswerView.swift
@@ -5,82 +5,82 @@ struct SelectAnswerView: View {
     @ObservedObject var viewModel: SubmitAnswerViewModel
     @State var searchTerm = ""
     @Environment(\.dismiss) private var dismiss
+    @FocusState private var isFocused: Bool
 
     private let debouncer = Debouncer(delay: 0.5)
 
     var body: some View {
-        NavigationStack {
-            VStack {
-                HStack {
-                    ASMusicItemCell(music: viewModel.selectedMusic, fetchArtwork: { url in
-                        await viewModel.downloadArtwork(url: url)
-                    })
-                    .scaleEffect(1.1)
-                    Spacer()
-                    Button {
-                        if viewModel.selectedMusic != nil {
-                            viewModel.isPlaying.toggle()
-                        }
-                    } label: {
-                        if #available(iOS 17.0, *) {
-                            Image(systemName: viewModel.isPlaying ? "stop.fill" : "play.fill")
-                                .font(.largeTitle)
-                                .contentTransition(.symbolEffect(.replace.offUp))
-                        } else {
-                            Image(systemName: viewModel.isPlaying ? "stop.fill" : "play.fill")
-                                .font(.largeTitle)
-                        }
+        VStack {
+            HStack {
+                ASMusicItemCell(music: viewModel.selectedMusic, fetchArtwork: { url in
+                    await viewModel.downloadArtwork(url: url)
+                })
+                .scaleEffect(1.1)
+                Spacer()
+                Button {
+                    if viewModel.selectedMusic != nil {
+                        viewModel.isPlaying.toggle()
                     }
-                    .tint(.primary)
-                    .frame(width: 60)
+                } label: {
+                    if #available(iOS 17.0, *) {
+                        Image(systemName: viewModel.isPlaying ? "stop.fill" : "play.fill")
+                            .font(.largeTitle)
+                            .contentTransition(.symbolEffect(.replace.offUp))
+                    } else {
+                        Image(systemName: viewModel.isPlaying ? "stop.fill" : "play.fill")
+                            .font(.largeTitle)
+                    }
                 }
-                .padding(16)
-
-                ASSearchBar(text: $searchTerm, placeHolder: "노래를 선택하세요")
-                    .onChange(of: searchTerm) { newValue in
-                        debouncer.debounce {
-                            Task {
-                                if newValue.isEmpty { viewModel.resetSearchList() }
-                                try await viewModel.searchMusic(text: newValue)
-                            }
-                        }
-                    }
-                    .onTapGesture {
-                        viewModel.sheetDetent = .large
-                    }
-                if viewModel.isSearching {
-                    VStack {
-                        Spacer()
-                        ProgressView()
-                            .scaleEffect(2.0)
-                        Spacer()
-                    }
-                } else {
-                    List(viewModel.searchList) { music in
-                        Button {
-                            viewModel.handleSelectedMusic(with: music)
-                        } label: {
-                            ASMusicItemCell(music: music, fetchArtwork: { url in
-                                await viewModel.downloadArtwork(url: url)
-                            })
-                            .tint(.black)
-                        }
-                    }
-                    .listStyle(.plain)
-                    .scrollDismissesKeyboard(.immediately)
-                }
+                .tint(.primary)
+                .frame(width: 60)
             }
-            .background(.asLightGray)
-            .toolbar {
-                ToolbarItem(placement: .topBarTrailing) {
-                    Button("완료") {
-                        viewModel.stopMusic()
-                        dismiss()
+            .padding(16)
+            .onTapGesture {
+                isFocused = false
+            }
+
+            ASSearchBar(text: $searchTerm, placeHolder: "노래를 선택하세요")
+                .onChange(of: searchTerm) { newValue in
+                    debouncer.debounce {
+                        Task {
+                            if newValue.isEmpty { viewModel.resetSearchList() }
+                            try await viewModel.searchMusic(text: newValue)
+                        }
                     }
+                }
+                .focused($isFocused)
+            if viewModel.isSearching {
+                VStack {
+                    Spacer()
+                    ProgressView()
+                        .scaleEffect(2.0)
+                    Spacer()
+                }
+            } else {
+                List(viewModel.searchList) { music in
+                    Button {
+                        viewModel.handleSelectedMusic(with: music)
+                    } label: {
+                        ASMusicItemCell(music: music, fetchArtwork: { url in
+                            await viewModel.downloadArtwork(url: url)
+                        })
+                        .tint(.black)
+                    }
+                }
+                .listStyle(.plain)
+                .edgesIgnoringSafeArea(.bottom)
+                .scrollDismissesKeyboard(.immediately)
+            }
+        }
+        .background(.asLightGray)
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                Button("완료") {
+                    viewModel.stopMusic()
+                    dismiss()
                 }
             }
         }
-        .presentationDragIndicator(.visible) // detents와 selection 연결
     }
 }
 

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SubmitAnswer/SelectAnswerView.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SubmitAnswer/SelectAnswerView.swift
@@ -5,6 +5,7 @@ struct SelectAnswerView: View {
     @ObservedObject var viewModel: SubmitAnswerViewModel
     @State var searchTerm = ""
     @Environment(\.dismiss) private var dismiss
+
     private let debouncer = Debouncer(delay: 0.5)
 
     var body: some View {
@@ -34,7 +35,7 @@ struct SelectAnswerView: View {
                     .frame(width: 60)
                 }
                 .padding(16)
-                
+
                 ASSearchBar(text: $searchTerm, placeHolder: "노래를 선택하세요")
                     .onChange(of: searchTerm) { newValue in
                         debouncer.debounce {
@@ -44,17 +45,30 @@ struct SelectAnswerView: View {
                             }
                         }
                     }
-                List(viewModel.searchList) { music in
-                    Button {
-                        viewModel.handleSelectedMusic(with: music)
-                    } label: {
-                        ASMusicItemCell(music: music, fetchArtwork: { url in
-                            await viewModel.downloadArtwork(url: url)
-                        })
-                        .tint(.black)
+                    .onTapGesture {
+                        viewModel.sheetDetent = .large
                     }
+                if viewModel.isSearching {
+                    VStack {
+                        Spacer()
+                        ProgressView()
+                            .scaleEffect(2.0)
+                        Spacer()
+                    }
+                } else {
+                    List(viewModel.searchList) { music in
+                        Button {
+                            viewModel.handleSelectedMusic(with: music)
+                        } label: {
+                            ASMusicItemCell(music: music, fetchArtwork: { url in
+                                await viewModel.downloadArtwork(url: url)
+                            })
+                            .tint(.black)
+                        }
+                    }
+                    .listStyle(.plain)
+                    .scrollDismissesKeyboard(.immediately)
                 }
-                .listStyle(.plain)
             }
             .background(.asLightGray)
             .toolbar {
@@ -66,6 +80,7 @@ struct SelectAnswerView: View {
                 }
             }
         }
+        .presentationDragIndicator(.visible) // detents와 selection 연결
     }
 }
 

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SubmitAnswer/SelectAnswerView.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SubmitAnswer/SelectAnswerView.swift
@@ -75,7 +75,7 @@ struct SelectAnswerView: View {
             }
             .background(.asLightGray)
             .toolbar {
-                ToolbarItem(placement: .navigationBarTrailing) {
+                ToolbarItem(placement: .topBarTrailing) {
                     Button("완료") {
                         viewModel.stopMusic()
                         dismiss()

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SubmitAnswer/SelectAnswerView.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SubmitAnswer/SelectAnswerView.swift
@@ -10,80 +10,78 @@ struct SelectAnswerView: View {
     private let debouncer = Debouncer(delay: 0.5)
 
     var body: some View {
-        VStack {
-            HStack {
-                ASMusicItemCell(music: viewModel.selectedMusic, fetchArtwork: { url in
-                    await viewModel.downloadArtwork(url: url)
-                })
-                .scaleEffect(1.1)
-                Spacer()
-                Button {
-                    if viewModel.selectedMusic != nil {
-                        viewModel.isPlaying.toggle()
-                    }
-                } label: {
-                    if #available(iOS 17.0, *) {
-                        Image(systemName: viewModel.isPlaying ? "stop.fill" : "play.fill")
-                            .font(.largeTitle)
-                            .contentTransition(.symbolEffect(.replace.offUp))
-                    } else {
-                        Image(systemName: viewModel.isPlaying ? "stop.fill" : "play.fill")
-                            .font(.largeTitle)
-                    }
-                }
-                .tint(.primary)
-                .frame(width: 60)
-            }
-            .padding(16)
-            .onTapGesture {
-                isFocused = false
-            }
-
-            ASSearchBar(text: $searchTerm, placeHolder: "노래를 선택하세요")
-                .onChange(of: searchTerm) { newValue in
-                    debouncer.debounce {
-                        Task {
-                            if newValue.isEmpty { viewModel.resetSearchList() }
-                            try await viewModel.searchMusic(text: newValue)
+        NavigationStack {
+            VStack {
+                HStack {
+                    ASMusicItemCell(music: viewModel.selectedMusic, fetchArtwork: { url in
+                        await viewModel.downloadArtwork(url: url)
+                    })
+                    .scaleEffect(1.1)
+                    Spacer()
+                    Button {
+                        if viewModel.selectedMusic != nil {
+                            viewModel.isPlaying.toggle()
+                        }
+                    } label: {
+                        if #available(iOS 17.0, *) {
+                            Image(systemName: viewModel.isPlaying ? "stop.fill" : "play.fill")
+                                .font(.largeTitle)
+                                .contentTransition(.symbolEffect(.replace.offUp))
+                        } else {
+                            Image(systemName: viewModel.isPlaying ? "stop.fill" : "play.fill")
+                                .font(.largeTitle)
                         }
                     }
+                    .tint(.primary)
+                    .frame(width: 60)
                 }
-                .focused($isFocused)
-            if viewModel.isSearching {
-                VStack {
-                    Spacer()
-                    ProgressView()
-                        .scaleEffect(2.0)
-                    Spacer()
+                .padding(16)
+                .onTapGesture {
+                    isFocused = false
                 }
-            } else {
-                List(viewModel.searchList) { music in
-                    Button {
-                        viewModel.handleSelectedMusic(with: music)
-                    } label: {
-                        ASMusicItemCell(music: music, fetchArtwork: { url in
-                            await viewModel.downloadArtwork(url: url)
-                        })
-                        .tint(.black)
+
+                ASSearchBar(text: $searchTerm, placeHolder: "노래를 선택하세요")
+                    .onChange(of: searchTerm) { newValue in
+                        debouncer.debounce {
+                            Task {
+                                if newValue.isEmpty { viewModel.resetSearchList() }
+                                try await viewModel.searchMusic(text: newValue)
+                            }
+                        }
                     }
+                    .focused($isFocused)
+                if viewModel.isSearching {
+                    VStack {
+                        Spacer()
+                        ProgressView()
+                            .scaleEffect(2.0)
+                        Spacer()
+                    }
+                } else {
+                    List(viewModel.searchList) { music in
+                        Button {
+                            viewModel.handleSelectedMusic(with: music)
+                        } label: {
+                            ASMusicItemCell(music: music, fetchArtwork: { url in
+                                await viewModel.downloadArtwork(url: url)
+                            })
+                            .tint(.black)
+                        }
+                    }
+                    .listStyle(.plain)
+                    .edgesIgnoringSafeArea(.bottom)
+                    .scrollDismissesKeyboard(.immediately)
                 }
-                .listStyle(.plain)
-                .edgesIgnoringSafeArea(.bottom)
-                .scrollDismissesKeyboard(.immediately)
             }
-        }
-        .background(.asLightGray)
-        .toolbar {
-            ToolbarItem(placement: .topBarTrailing) {
-                Button("완료") {
-                    viewModel.stopMusic()
-                    dismiss()
+            .background(.asLightGray)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button("완료") {
+                        viewModel.stopMusic()
+                        dismiss()
+                    }
                 }
             }
         }
     }
-}
-
-#Preview {
-//    SelectMusicView(v)
 }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SubmitAnswer/SelectAnswerView.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SubmitAnswer/SelectAnswerView.swift
@@ -20,11 +20,11 @@ struct SelectAnswerView: View {
                         viewModel.isPlaying.toggle()
                     } label: {
                         if #available(iOS 17.0, *) {
-                            Image(systemName: viewModel.isPlaying ? "pause.fill" : "play.fill")
+                            Image(systemName: viewModel.isPlaying ? "stop.fill" : "play.fill")
                                 .font(.largeTitle)
                                 .contentTransition(.symbolEffect(.replace.offUp))
                         } else {
-                            Image(systemName: viewModel.isPlaying ? "pause.fill" : "play.fill")
+                            Image(systemName: viewModel.isPlaying ? "stop.fill" : "play.fill")
                                 .font(.largeTitle)
                         }
                     }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SubmitAnswer/SubmitAnswerViewController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SubmitAnswer/SubmitAnswerViewController.swift
@@ -41,6 +41,7 @@ final class SubmitAnswerViewController: UIViewController {
         musicPanel.bind(to: viewModel.$music)
         selectedMusicPanel.bind(to: viewModel.$selectedMusic)
         submitButton.bind(to: viewModel.$musicData)
+
     }
 
     private func setupUI() {

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SubmitAnswer/SubmitAnswerViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SubmitAnswer/SubmitAnswerViewModel.swift
@@ -120,10 +120,10 @@ final class SubmitAnswerViewModel: ObservableObject, @unchecked Sendable {
     public func searchMusic(text: String) async throws {
         do {
             if text.isEmpty { return }
-            isSearching = true
+            await updateIsSearching(with: true)
             let searchList = try await musicAPI.search(for: text)
             await updateSearchList(with: searchList)
-            isSearching = false
+            await updateIsSearching(with: false)
         } catch {
             throw error
         }
@@ -180,6 +180,11 @@ final class SubmitAnswerViewModel: ObservableObject, @unchecked Sendable {
     @MainActor
     private func updateSearchList(with searchList: [Music]) {
         self.searchList = searchList
+    }
+    
+    @MainActor
+    private func updateIsSearching(with isSearching: Bool) {
+        self.isSearching = isSearching
     }
     
     public func cancelSubscriptions() {

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SubmitAnswer/SubmitAnswerViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SubmitAnswer/SubmitAnswerViewModel.swift
@@ -7,6 +7,7 @@ import Foundation
 final class SubmitAnswerViewModel: ObservableObject, @unchecked Sendable {
     @Published public private(set) var searchList: [Music] = []
     @Published public private(set) var selectedMusic: Music?
+    @Published public private(set) var isSearching: Bool = false
     @Published public private(set) var dueTime: Date?
     @Published public private(set) var recordOrder: UInt8?
     @Published public private(set) var status: Status?
@@ -119,8 +120,10 @@ final class SubmitAnswerViewModel: ObservableObject, @unchecked Sendable {
     public func searchMusic(text: String) async throws {
         do {
             if text.isEmpty { return }
+            isSearching = true
             let searchList = try await musicAPI.search(for: text)
             await updateSearchList(with: searchList)
+            isSearching = false
         } catch {
             throw error
         }


### PR DESCRIPTION
## What is this PR?
- 노래 선택할 때 중지가 아니라 정지 버튼으로 수정
- 노래 선택할 때 선택한 노래가 없으면 재생버튼 막기
- 노래 검색 중일때만 progress 동작
- 노래 선택할 때 키보드가 안내려가는 문제 해결

## PR Type
- [x] Bugfix
- [ ] Chore
- [ ] New feature (기능을 추가하는 feat)
- [ ] Breaking change (기존의 기능이 동작하지 않을 수 있는 fix/feat)
- [ ] Documentation Update

## ScreenShot(if available)
| 노래선택 | 정답제출 |
| - | - |
|<img src = "https://github.com/user-attachments/assets/f840b01b-534a-4fcd-9024-e1187f06fa55" width ="250">|<img src = "https://github.com/user-attachments/assets/043ad844-32fe-4339-a4d8-da42c9bfa696" width ="250">|

## Further comments

### 시도 해본 것들
* Tap gesture 사용
  * List의 cell들이 터치가 안되는 문제 발생
*  SwiftUI 에서 Sheet로 올리고, 안에 TextField가 있는 경우에 텍스트 필드에 Focus가 없어질 때 키보드가 내려가는 애니메이션 중, 2번에 걸쳐서 내려가는 문제가 있습니다. ( 찾아봐도 같은 이슈를 겪는 사람은 많았지만 해결하는 방법은 찾지 못했습니다. )
* 2번 걸쳐서 내려가는 문제 중 중간에 셀이 깨지는 현상이 있었는데, bottom에 safeAreaignore 처리해서 해결했습니다.
